### PR TITLE
refactor! using dedicated XY and XYZ structs

### DIFF
--- a/commons/src/float_grid.rs
+++ b/commons/src/float_grid.rs
@@ -1,6 +1,7 @@
 use image::{ImageBuffer, Luma};
 use num::Float;
 
+use crate::geometry::xy;
 use crate::grid::Grid;
 use crate::scale::Scale;
 use crate::unsafe_float_ordering;
@@ -39,7 +40,7 @@ where
         let scale = Scale::new((min, max), (T::zero(), T::one()));
 
         let image = ImageBuffer::from_fn(self.width(), self.height(), |x, y| {
-            let scaled = scale.scale(self[(x, y)]);
+            let scaled = scale.scale(self[xy(x, y)]);
 
             let luma = scaled * T::from(255u8).unwrap();
             let luma = luma.round();
@@ -55,18 +56,20 @@ where
 mod tests {
     use std::env::temp_dir;
 
+    use crate::geometry::XY;
+
     use super::*;
 
     #[test]
     fn test_min() {
-        let grid = Grid::from_fn(3, 3, |(x, y)| (x + y) as f32 + 1.0);
+        let grid = Grid::from_fn(3, 3, |XY { x, y }| (x + y) as f32 + 1.0);
 
         assert_eq!(grid.min(), 1.0);
     }
 
     #[test]
     fn test_max() {
-        let grid = Grid::from_fn(3, 3, |(x, y)| (x + y) as f32 + 1.0);
+        let grid = Grid::from_fn(3, 3, |XY { x, y }| (x + y) as f32 + 1.0);
 
         assert_eq!(grid.max(), 5.0);
     }
@@ -100,7 +103,7 @@ mod tests {
     #[test]
     fn test_to_image() {
         // given
-        let grid = Grid::from_fn(128, 128, |(x, y)| (x + y) as f32 + 1.0);
+        let grid = Grid::from_fn(128, 128, |XY { x, y }| (x + y) as f32 + 1.0);
 
         // when
         let temp_path = temp_dir().join("test_to_image.png");

--- a/commons/src/geometry.rs
+++ b/commons/src/geometry.rs
@@ -1,3 +1,56 @@
+use std::fmt::Display;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct XY<T> {
+    pub x: T,
+    pub y: T,
+}
+
+pub const fn xy<T>(x: T, y: T) -> XY<T> {
+    XY { x, y }
+}
+
+impl<T> Display for XY<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({} {})", self.x, self.y)
+    }
+}
+
+impl<T> From<XY<T>> for [T; 2] {
+    fn from(position: XY<T>) -> Self {
+        [position.x, position.y]
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct XYZ<T> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
+pub const fn xyz<T>(x: T, y: T, z: T) -> XYZ<T> {
+    XYZ { x, y, z }
+}
+
+impl<T> Display for XYZ<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({} {} {})", self.x, self.y, self.z)
+    }
+}
+
+impl<T> From<XYZ<T>> for [T; 3] {
+    fn from(position: XYZ<T>) -> Self {
+        [position.x, position.y, position.z]
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct Rectangle<T> {
     pub width: T,

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -2,7 +2,7 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use commons::color::Rgb;
-use commons::geometry::Rectangle;
+use commons::geometry::{xy, xyz, Rectangle};
 use commons::grid::Grid;
 use commons::noise::simplex_noise;
 use engine::engine::Engine;
@@ -80,15 +80,15 @@ impl EventHandler for Demo {
             );
             for x in 0..terrain.width() - 1 {
                 for y in 0..terrain.height() - 1 {
-                    let z = terrain[(x, y)];
-                    let corners = [(0, 0), (1, 0), (1, 1), (0, 1)]
+                    let z = terrain[xy(x, y)];
+                    let corners = [xy(0, 0), xy(1, 0), xy(1, 1), xy(0, 1)]
                         .iter()
-                        .map(|(dx, dy)| {
-                            [
-                                (x + dx) as f32,
-                                (y + dy) as f32,
-                                terrain[(x + dx, y + dy)] * 32.0,
-                            ]
+                        .map(|d| {
+                            xyz(
+                                (x + d.x) as f32,
+                                (y + d.y) as f32,
+                                terrain[xy(x + d.x, y + d.y)] * 32.0,
+                            )
                         })
                         .collect::<Vec<_>>();
                     quads.push(Quad {
@@ -99,7 +99,7 @@ impl EventHandler for Demo {
             }
 
             graphics.add_quads(&quads).unwrap();
-            graphics.look_at(&[128.0, 128.0, 0.0], &(256, 256));
+            graphics.look_at(&xyz(128.0, 128.0, 0.0), &xy(256, 256));
         } else if self.frame == 1 {
             graphics.screenshot("screenshot.png").unwrap();
         }

--- a/engine/src/events.rs
+++ b/engine/src/events.rs
@@ -1,4 +1,4 @@
-use commons::geometry::Rectangle;
+use commons::geometry::{Rectangle, XY};
 
 use crate::engine::Engine;
 use crate::graphics::Graphics;
@@ -72,7 +72,7 @@ pub enum KeyboardKey {
 
 pub enum Event {
     Tick,
-    MouseMoved((u32, u32)),
+    MouseMoved(XY<u32>),
     MouseInput {
         button: MouseButton,
         state: ButtonState,

--- a/engine/src/glium_backend/engine.rs
+++ b/engine/src/glium_backend/engine.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::time::Duration;
 
-use commons::geometry::Rectangle;
+use commons::geometry::{xy, Rectangle};
 use glium::glutin;
 use glium::glutin::event::MouseScrollDelta;
 
@@ -80,8 +80,9 @@ where
                         return;
                     }
                     glutin::event::WindowEvent::CursorMoved { position, .. } => {
+                        let (x, y) = position.into();
                         self.event_handler.handle(
-                            &Event::MouseMoved(position.into()),
+                            &Event::MouseMoved(xy(x, y)),
                             &mut self.state,
                             &mut self.graphics,
                         );

--- a/engine/src/glium_backend/graphics/canvas.rs
+++ b/engine/src/glium_backend/graphics/canvas.rs
@@ -1,3 +1,4 @@
+use commons::geometry::XY;
 use std::error::Error;
 use thiserror::Error;
 
@@ -80,7 +81,7 @@ impl Canvas {
         Ok(())
     }
 
-    pub fn read_pixel(&self, (x, y): (u32, u32)) -> Result<Rgba<f32>, ReadPixelError> {
+    pub fn read_pixel(&self, XY { x, y }: XY<u32>) -> Result<Rgba<f32>, ReadPixelError> {
         if x > self.texture.width() || y > self.texture.height() {
             return Err(ReadPixelError::OutOfBounds {
                 xy: (x, y),

--- a/engine/src/glium_backend/graphics/tests.rs
+++ b/engine/src/glium_backend/graphics/tests.rs
@@ -13,14 +13,14 @@ use crate::handlers::{drag, resize, yaw, zoom};
 use super::*;
 
 fn cube_quads() -> Vec<Quad> {
-    let la = [-0.5, -0.5, -0.5];
-    let lb = [0.5, -0.5, -0.5];
-    let lc = [0.5, 0.5, -0.5];
-    let ld = [-0.5, 0.5, -0.5];
-    let ua = [-0.5, -0.5, 0.5];
-    let ub = [0.5, -0.5, 0.5];
-    let uc = [0.5, 0.5, 0.5];
-    let ud = [-0.5, 0.5, 0.5];
+    let la = xyz(-0.5, -0.5, -0.5);
+    let lb = xyz(0.5, -0.5, -0.5);
+    let lc = xyz(0.5, 0.5, -0.5);
+    let ld = xyz(-0.5, 0.5, -0.5);
+    let ua = xyz(-0.5, -0.5, 0.5);
+    let ub = xyz(0.5, -0.5, 0.5);
+    let uc = xyz(0.5, 0.5, 0.5);
+    let ud = xyz(-0.5, 0.5, 0.5);
 
     vec![
         Quad {
@@ -114,7 +114,7 @@ fn look_at() {
 
     // when
     graphics.add_quads(&cube_quads()).unwrap();
-    graphics.look_at(&[-0.5, -0.5, -0.5], &(192, 64));
+    graphics.look_at(&xyz(-0.5, -0.5, -0.5), &xy(192, 64));
     graphics.render().unwrap();
 
     let temp_path = temp_dir().join("test.png");
@@ -127,7 +127,7 @@ fn look_at() {
     assert_eq!(actual, expected);
 
     // when
-    graphics.look_at(&[-0.5, -0.5, -0.5], &(192, 64));
+    graphics.look_at(&xyz(-0.5, -0.5, -0.5), &xy(192, 64));
     graphics.render().unwrap();
     graphics.screenshot(temp_path).unwrap();
 
@@ -173,7 +173,7 @@ fn drag_handler() {
 
     // when
     drag_handler.handle(
-        &Event::MouseMoved((100, 150)),
+        &Event::MouseMoved(xy(100, 150)),
         &mut MockEngine {},
         &mut graphics,
     );
@@ -186,7 +186,7 @@ fn drag_handler() {
         &mut graphics,
     );
     drag_handler.handle(
-        &Event::MouseMoved((80, 170)),
+        &Event::MouseMoved(xy(80, 170)),
         &mut MockEngine {},
         &mut graphics,
     );
@@ -244,7 +244,7 @@ fn yaw_handler() {
 
     // when
     yaw_handler.handle(
-        &Event::MouseMoved((100, 150)),
+        &Event::MouseMoved(xy(100, 150)),
         &mut MockEngine {},
         &mut graphics,
     );
@@ -269,7 +269,7 @@ fn yaw_handler() {
 
     // when
     yaw_handler.handle(
-        &Event::MouseMoved((100, 150)),
+        &Event::MouseMoved(xy(100, 150)),
         &mut MockEngine {},
         &mut graphics,
     );
@@ -336,7 +336,7 @@ fn zoom_handler() {
 
     // when
     yaw_handler.handle(
-        &Event::MouseMoved((100, 150)),
+        &Event::MouseMoved(xy(100, 150)),
         &mut MockEngine {},
         &mut graphics,
     );
@@ -361,7 +361,7 @@ fn zoom_handler() {
 
     // when
     yaw_handler.handle(
-        &Event::MouseMoved((100, 150)),
+        &Event::MouseMoved(xy(100, 150)),
         &mut MockEngine {},
         &mut graphics,
     );

--- a/engine/src/graphics/elements.rs
+++ b/engine/src/graphics/elements.rs
@@ -1,11 +1,12 @@
 use commons::color::Rgb;
+use commons::geometry::XYZ;
 
 pub struct Triangle {
-    pub corners: [[f32; 3]; 3],
+    pub corners: [XYZ<f32>; 3],
     pub color: Rgb<f32>,
 }
 
 pub struct Quad {
-    pub corners: [[f32; 3]; 4],
+    pub corners: [XYZ<f32>; 4],
     pub color: Rgb<f32>,
 }

--- a/engine/src/graphics/mod.rs
+++ b/engine/src/graphics/mod.rs
@@ -4,7 +4,7 @@ pub mod matrices;
 pub mod projection;
 pub mod projections;
 
-use commons::geometry::Rectangle;
+use commons::geometry::{Rectangle, XY, XYZ};
 pub use projection::Projection;
 
 use elements::*;
@@ -43,7 +43,7 @@ pub trait Graphics {
         self.add_triangles(&triangles)
     }
 
-    fn look_at(&mut self, world_xyz: &[f32; 3], screen_xy: &(u32, u32));
+    fn look_at(&mut self, world_xyz: &XYZ<f32>, screen_xy: &XY<u32>);
 
     fn yaw(&mut self, yaw: f32);
 
@@ -51,5 +51,5 @@ pub trait Graphics {
 
     fn set_viewport(&mut self, viewport: Rectangle<u32>);
 
-    fn world_xyz_at(&mut self, screen_xy: &(u32, u32)) -> Result<[f32; 3], IndexError>;
+    fn world_xyz_at(&mut self, screen_xy: &XY<u32>) -> Result<XYZ<f32>, IndexError>;
 }

--- a/engine/src/graphics/projection.rs
+++ b/engine/src/graphics/projection.rs
@@ -1,9 +1,9 @@
-use commons::geometry::Rectangle;
+use commons::geometry::{Rectangle, XY, XYZ};
 
 pub trait Projection {
     fn projection(&self) -> &[[f32; 4]; 4];
-    fn unproject(&self, gl_xyz: &[f32; 3]) -> [f32; 3];
-    fn look_at(&mut self, world_xyz: &[f32; 3], screen_xy: &[f32; 2]);
+    fn unproject(&self, gl_xyz: &XYZ<f32>) -> XYZ<f32>;
+    fn look_at(&mut self, world_xyz: &XYZ<f32>, screen_xy: &XY<f32>);
     fn yaw(&mut self, yaw: f32);
     fn zoom(&mut self, zoom: f32);
     fn set_viewport(&mut self, viewport: Rectangle<u32>);

--- a/engine/src/graphics/projections/isometric.rs
+++ b/engine/src/graphics/projections/isometric.rs
@@ -1,4 +1,4 @@
-use commons::geometry::Rectangle;
+use commons::geometry::{xy, xyz, Rectangle, XY, XYZ};
 use nalgebra::{Matrix4, Vector4};
 
 use crate::graphics;
@@ -75,20 +75,20 @@ impl graphics::Projection for Projection {
         &self.composite
     }
 
-    fn unproject(&self, [x, y, z]: &[f32; 3]) -> [f32; 3] {
+    fn unproject(&self, XYZ { x, y, z }: &XYZ<f32>) -> XYZ<f32> {
         let gl_xyz = Vector4::new(*x, *y, *z, 1.0);
         let unprojected = self.inverse * gl_xyz;
-        [unprojected.x, unprojected.y, unprojected.z]
+        xyz(unprojected.x, unprojected.y, unprojected.z)
     }
 
-    fn look_at(&mut self, world_xyz: &[f32; 3], screen_xy: &[f32; 2]) {
-        let world = Vector4::new(world_xyz[0], world_xyz[1], world_xyz[2], 1.0);
+    fn look_at(&mut self, world: &XYZ<f32>, screen: &XY<f32>) {
+        let world = Vector4::new(world.x, world.y, world.z, 1.0);
         let composite: Matrix4<f32> = self.composite.into();
 
         let offsets = composite * world;
 
-        self.matrices.translation[(0, 3)] += -offsets.x + screen_xy[0];
-        self.matrices.translation[(1, 3)] += -offsets.y + screen_xy[1];
+        self.matrices.translation[(0, 3)] += -offsets.x + screen.x;
+        self.matrices.translation[(1, 3)] += -offsets.y + screen.y;
 
         self.update_composite();
     }
@@ -113,7 +113,7 @@ impl graphics::Projection for Projection {
 
         self.update_composite();
 
-        self.look_at(&[center[0], center[1], 0.0], &[0.0, 0.0])
+        self.look_at(&xyz(center[0], center[1], 0.0), &xy(0.0, 0.0))
     }
 }
 

--- a/engine/src/handlers/drag.rs
+++ b/engine/src/handlers/drag.rs
@@ -1,3 +1,5 @@
+use commons::geometry::{XY, XYZ};
+
 use crate::{
     engine::Engine,
     events::{ButtonState, Event, EventHandler, MouseButton},
@@ -5,8 +7,8 @@ use crate::{
 };
 
 pub struct Handler {
-    mouse_xy: Option<(u32, u32)>,
-    selection: Option<[f32; 3]>,
+    mouse_xy: Option<XY<u32>>,
+    selection: Option<XYZ<f32>>,
 }
 
 impl Handler {

--- a/engine/src/handlers/yaw.rs
+++ b/engine/src/handlers/yaw.rs
@@ -1,5 +1,7 @@
 use std::f32::consts::PI;
 
+use commons::geometry::XY;
+
 use crate::{
     engine::Engine,
     events::{ButtonState, Event, EventHandler, KeyboardKey},
@@ -11,7 +13,7 @@ pub struct Handler {
     angles: usize,
     key_plus: KeyboardKey,
     key_minus: KeyboardKey,
-    mouse_xy: Option<(u32, u32)>,
+    mouse_xy: Option<XY<u32>>,
 }
 
 pub struct Parameters {

--- a/engine/src/handlers/zoom.rs
+++ b/engine/src/handlers/zoom.rs
@@ -1,3 +1,5 @@
+use commons::geometry::XY;
+
 use crate::{
     engine::Engine,
     events::{ButtonState, Event, EventHandler, KeyboardKey},
@@ -10,7 +12,7 @@ pub struct Handler {
     max_level: i32,
     key_plus: KeyboardKey,
     key_minus: KeyboardKey,
-    mouse_xy: Option<(u32, u32)>,
+    mouse_xy: Option<XY<u32>>,
 }
 
 pub struct Parameters {

--- a/terrain_gen/src/downhills.rs
+++ b/terrain_gen/src/downhills.rs
@@ -1,9 +1,10 @@
+use commons::geometry::{xy, XY};
 use commons::grid::Grid;
 use commons::unsafe_float_ordering;
 
 use crate::Heightmap;
 
-pub type Downhills = Grid<Option<(i32, i32)>>;
+pub type Downhills = Grid<Option<XY<i32>>>;
 
 pub trait Downhill {
     fn downhills(&self) -> Downhills;
@@ -15,19 +16,19 @@ impl Downhill for Heightmap {
     }
 }
 
-fn lowest_neighbour(heightmap: &Heightmap, xy: &(u32, u32)) -> Option<(u32, u32)> {
+fn lowest_neighbour(heightmap: &Heightmap, position: &XY<u32>) -> Option<XY<u32>> {
     heightmap
-        .neighbours_4(xy)
-        .filter(|neighbour| heightmap[neighbour] < heightmap[xy])
+        .neighbours_4(position)
+        .filter(|neighbour| heightmap[neighbour] < heightmap[position])
         .min_by(|a, b| unsafe_float_ordering(&heightmap[a], &heightmap[b]))
 }
 
-fn lowest_neighbour_offset(heightmap: &Heightmap, xy: &(u32, u32)) -> Option<(i32, i32)> {
-    let (x, y) = xy;
-    lowest_neighbour(heightmap, xy).map(|(nx, ny)| {
-        (
-            (nx as i64 - *x as i64) as i32,
-            (ny as i64 - *y as i64) as i32,
+fn lowest_neighbour_offset(heightmap: &Heightmap, position: &XY<u32>) -> Option<XY<i32>> {
+    let XY { x, y } = position;
+    lowest_neighbour(heightmap, position).map(|n| {
+        xy(
+            (n.x as i64 - *x as i64) as i32,
+            (n.y as i64 - *y as i64) as i32,
         )
     })
 }
@@ -55,9 +56,9 @@ mod tests {
                 3,
                 3,
                 vec![
-                    None, Some((-1, 0)), Some((-1, 0)), // 
-                    Some((0, -1)), Some((0, 1)), Some((-1, 0)), // 
-                    Some((1, 0)), None, Some((-1, 0)), // 
+                    None, Some(xy(-1, 0)), Some(xy(-1, 0)), // 
+                    Some(xy(0, -1)), Some(xy(0, 1)), Some(xy(-1, 0)), // 
+                    Some(xy(1, 0)), None, Some(xy(-1, 0)), // 
                 ]
             )
         );

--- a/terrain_gen/src/heightmap_from_rises/mod.rs
+++ b/terrain_gen/src/heightmap_from_rises/mod.rs
@@ -3,6 +3,7 @@ pub mod with_valleys;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
+use commons::geometry::XY;
 use commons::grid::Grid;
 use commons::unsafe_float_ordering;
 
@@ -10,7 +11,7 @@ use crate::{Heightmap, Rises};
 
 pub fn heightmap_from_rises<F>(rises: &Rises, origin_fn: F) -> Heightmap
 where
-    F: Fn((u32, u32)) -> bool,
+    F: Fn(XY<u32>) -> bool,
 {
     let mut visited = Grid::<bool>::default(rises.width(), rises.height());
     let mut out = Grid::from_fn(rises.width(), rises.height(), |xy| {
@@ -55,7 +56,7 @@ where
 }
 
 struct HeapElement {
-    xy: (u32, u32),
+    xy: XY<u32>,
     z: f32,
 }
 

--- a/terrain_gen/src/heightmap_from_rises/with_valleys.rs
+++ b/terrain_gen/src/heightmap_from_rises/with_valleys.rs
@@ -1,12 +1,13 @@
 use std::borrow::Borrow;
 
+use commons::geometry::XY;
 use commons::scale::Scale;
 
 use crate::{heightmap_from_rises, Heightmap, Rain, Rises};
 
 pub struct ValleyParameters<F>
 where
-    F: Fn((u32, u32)) -> bool,
+    F: Fn(XY<u32>) -> bool,
 {
     pub height_threshold: f32,
     pub rain_threshold: usize,
@@ -17,7 +18,7 @@ where
 pub fn heightmap_from_rises_with_valleys<B, F>(rises: &Rises, parameters: B) -> Heightmap
 where
     B: Borrow<ValleyParameters<F>>,
-    F: Fn((u32, u32)) -> bool,
+    F: Fn(XY<u32>) -> bool,
 {
     let parameters = parameters.borrow();
 


### PR DESCRIPTION
This tidies up the inconsistent use of arrays and tuples for coordinates as well as clarifying intent (e.g. position.x instead of position.0).