### PR TITLE
fix: demo not looking at right part of terrain

### DIFF
--- a/commons/src/geometry.rs
+++ b/commons/src/geometry.rs
@@ -51,7 +51,7 @@ impl<T> From<XYZ<T>> for [T; 3] {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Rectangle<T> {
     pub width: T,
     pub height: T,

--- a/engine/src/graphics/projections/isometric.rs
+++ b/engine/src/graphics/projections/isometric.rs
@@ -106,6 +106,9 @@ impl graphics::Projection for Projection {
     }
 
     fn set_viewport(&mut self, viewport: Rectangle<u32>) {
+        if self.scale.viewport == viewport {
+            return;
+        }
         self.scale.viewport = viewport;
         self.update_scale();
 

--- a/engine/test.sh
+++ b/engine/test.sh
@@ -1,1 +1,0 @@
-cargo test -- --test-threads=1

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,2 @@
-cargo test --workspace --exclude engine
+cargo test --workspace --exclude engine &&
+cargo test --package engine -- --test-threads=1


### PR DESCRIPTION
A resize event is fired when the window is created, which the resize handler processes this before there is anything rendered to the screen and thinks (0, 0) is in the center of the screen and so looks there - overriding the initial look_at call.

Ignoring viewport resizes when the viewport doesn't change size makes it harder for this to happen.