### PR TITLE
refactor (mountain): removing use statements from model module

### DIFF
--- a/mountain/src/handlers/add_skier.rs
+++ b/mountain/src/handlers/add_skier.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 use commons::geometry::{xy, XY, XYZ};
 use engine::binding::Binding;
 
+use crate::model::direction::Direction;
+use crate::model::skiing;
 use crate::model::skiing::Mode;
-use crate::model::{skiing, Direction};
 use crate::services::id_allocator;
 
 pub struct Handler {

--- a/mountain/src/handlers/lift_builder.rs
+++ b/mountain/src/handlers/lift_builder.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use commons::geometry::{xy, XYRectangle, XY, XYZ};
 use engine::binding::Binding;
 
-use crate::model::Lift;
+use crate::model::lift::Lift;
 use crate::services::id_allocator;
 use crate::systems::overlay;
 

--- a/mountain/src/handlers/piste_builder.rs
+++ b/mountain/src/handlers/piste_builder.rs
@@ -4,7 +4,7 @@ use commons::origin_grid::OriginGrid;
 use engine::binding::Binding;
 
 use crate::handlers::selection;
-use crate::model::Piste;
+use crate::model::piste::Piste;
 use crate::services::id_allocator;
 use crate::systems::overlay;
 

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -28,7 +28,9 @@ use crate::handlers::{add_skier, piste_builder};
 use crate::handlers::{lift_builder, selection};
 use crate::init::generate_heightmap;
 use crate::model::frame::Frame;
-use crate::model::{skiing, Lift, Piste, PisteCosts};
+use crate::model::lift::Lift;
+use crate::model::piste::{Piste, PisteCosts};
+use crate::model::skiing;
 use crate::services::id_allocator;
 use crate::systems::{avatar_artist, cost_computer, framer, lift, lift_entry, overlay, planner};
 

--- a/mountain/src/model/mod.rs
+++ b/mountain/src/model/mod.rs
@@ -1,10 +1,5 @@
-mod direction;
+pub mod direction;
 pub mod frame;
-mod lift;
-mod piste;
+pub mod lift;
+pub mod piste;
 pub mod skiing;
-
-pub use direction::*;
-pub use lift::*;
-pub use piste::*;
-pub use skiing::*;

--- a/mountain/src/model/skiing.rs
+++ b/mountain/src/model/skiing.rs
@@ -1,6 +1,6 @@
 use commons::geometry::XY;
 
-use crate::model::Direction;
+use crate::model::direction::Direction;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct State {

--- a/mountain/src/network/skiing.rs
+++ b/mountain/src/network/skiing.rs
@@ -5,11 +5,10 @@ use std::time::Duration;
 use commons::{geometry::XY, grid::Grid};
 use network::model::{Edge, InNetwork, OutNetwork};
 
+use crate::model::direction::{Direction, DIRECTIONS};
 use crate::model::skiing::{Mode, State};
-use crate::model::DIRECTIONS;
 use crate::network::velocity_encoding::VELOCITY_LEVELS;
 use crate::{
-    model::Direction,
     network::velocity_encoding::{decode_velocity, encode_velocity},
     physics,
 };

--- a/mountain/src/systems/cost_computer.rs
+++ b/mountain/src/systems/cost_computer.rs
@@ -3,8 +3,10 @@ use std::collections::{HashMap, HashSet};
 use commons::geometry::XY;
 use commons::grid::Grid;
 
+use crate::model::direction::DIRECTIONS;
+use crate::model::lift::Lift;
+use crate::model::piste::{Piste, PisteCosts};
 use crate::model::skiing::{Mode, State};
-use crate::model::{Lift, Piste, PisteCosts, DIRECTIONS};
 use crate::network::skiing::{SkiingInNetwork, SkiingNetwork};
 use crate::network::velocity_encoding::{encode_velocity, VELOCITY_LEVELS};
 use network::algorithms::costs_to_target::CostsToTarget;

--- a/mountain/src/systems/lift.rs
+++ b/mountain/src/systems/lift.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use commons::grid::Grid;
 
+use crate::model::lift::Lift;
 use crate::model::skiing::{Mode, Plan, State};
-use crate::model::Lift;
 
 pub fn run(
     lifts: &HashMap<usize, Lift>,

--- a/mountain/src/systems/lift_entry.rs
+++ b/mountain/src/systems/lift_entry.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
+use crate::model::lift::Lift;
 use crate::model::skiing::{Plan, State};
-use crate::model::Lift;
 
 pub fn run(
     plans: &HashMap<usize, Plan>,

--- a/mountain/src/systems/overlay.rs
+++ b/mountain/src/systems/overlay.rs
@@ -7,7 +7,8 @@ use engine::graphics::Graphics;
 
 use crate::draw::terrain;
 use crate::handlers::selection;
-use crate::model::{Lift, Piste};
+use crate::model::lift::Lift;
+use crate::model::piste::Piste;
 
 pub const CLEAR: Rgba<u8> = Rgba::new(0, 0, 0, 0);
 

--- a/mountain/src/systems/planner.rs
+++ b/mountain/src/systems/planner.rs
@@ -5,8 +5,8 @@ use commons::geometry::XY;
 use commons::grid::Grid;
 use network::model::Edge;
 
+use crate::model::piste::PisteCosts;
 use crate::model::skiing::{Event, Mode, Plan, State};
-use crate::model::PisteCosts;
 use crate::network::skiing::SkiingNetwork;
 
 use network::algorithms::find_best_within_steps::FindBestWithinSteps;


### PR DESCRIPTION
This is to allow model structs with the same names (like Mode)