### PR TITLE
feat (mountain): prevent skiers from ending on white tiles

### DIFF
--- a/mountain/src/systems/planner.rs
+++ b/mountain/src/systems/planner.rs
@@ -204,10 +204,16 @@ fn find_path(
     network.find_best_within_steps(
         HashSet::from([*from]),
         &|_, state| {
-            if state.position == from.position {
+            let cost = costs.get(state);
+
+            // check for forbidden tiles
+            if cost != Some(&0) // goal tile is never forbidden
+                && (state.position == from.position || is_white_tile(&state.position))
+            {
                 return None;
             }
-            costs.get(state).map(|&cost| Score {
+
+            cost.map(|&cost| Score {
                 cost,
                 mode: state.mode,
             })
@@ -220,6 +226,10 @@ fn find_path(
         },
         MAX_STEPS,
     )
+}
+
+fn is_white_tile(position: &XY<u32>) -> bool {
+    position.x % 2 == position.y % 2
 }
 
 fn brake(state: State) -> Plan {


### PR DESCRIPTION
White tiles refers to "diagonal tiles" like the white tiles on a chessboard.

This prevents gridlock by making sure the black tiles are always free to path through.