### PR TITLE
chore: setting resolver=2 in workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "commons",


### PR DESCRIPTION
This was recommended by an error message