### PR TITLE
fix (mountain): lift builder now uses round()

### DIFF
--- a/mountain/src/handlers/lift_builder.rs
+++ b/mountain/src/handlers/lift_builder.rs
@@ -39,7 +39,7 @@ impl Handler {
         let Ok(XYZ { x, y, .. }) = graphics.world_xyz_at(mouse_xy) else {
             return;
         };
-        let position = xy(x.floor() as u32, y.floor() as u32);
+        let position = xy(x.round() as u32, y.round() as u32);
 
         let Some(from) = self.from else {
             self.from = Some(position);


### PR DESCRIPTION
This is because lifts are point, not tile, based