### PR TITLE
fix (commons): incorrect PartialOrd implementation

### DIFF
--- a/commons/src/unsafe_ordering.rs
+++ b/commons/src/unsafe_ordering.rs
@@ -29,7 +29,7 @@ where
     T: PartialOrd,
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.value.partial_cmp(&other.value)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
From clippy lint