### PR TITLE
fix (mountain): pausing game when saving

### DIFF
--- a/mountain/src/handlers/save.rs
+++ b/mountain/src/handlers/save.rs
@@ -10,11 +10,14 @@ pub struct Handler {
 }
 
 impl Handler {
-    pub fn handle(&self, event: &engine::events::Event, components: &Components) {
+    pub fn handle(&self, event: &engine::events::Event, components: &mut Components) {
         if !self.binding.binds_event(event) {
             return;
         }
         let mut file = BufWriter::new(File::create("default.save").unwrap());
+        let speed = components.services.clock.speed();
+        components.services.clock.set_speed(0.0);
         bincode::serialize_into(&mut file, components).unwrap();
+        components.services.clock.set_speed(speed);
     }
 }

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -370,7 +370,7 @@ impl EventHandler for Game {
                 id_allocator: &mut self.components.services.id_allocator,
                 entrances: &mut self.components.entrances,
             });
-        self.handlers.save.handle(event, &self.components);
+        self.handlers.save.handle(event, &mut self.components);
         self.handlers
             .selection
             .handle(event, &self.mouse_xy, graphics, &mut self.systems.overlay);

--- a/mountain/src/services/clock.rs
+++ b/mountain/src/services/clock.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct Service {
     #[serde(skip, default = "Instant::now")]
     baseline: Instant,
-    real_to_game: f32,
+    speed: f32,
     offset_micros: u128,
 }
 
@@ -14,7 +14,7 @@ impl Service {
     pub fn new() -> Service {
         Service {
             baseline: Instant::now(),
-            real_to_game: 1.0,
+            speed: 1.0,
             offset_micros: 0,
         }
     }
@@ -26,15 +26,19 @@ impl Service {
     fn get_micros_at(&self, instant: &Instant) -> u128 {
         instant
             .duration_since(self.baseline)
-            .mul_f32(self.real_to_game)
+            .mul_f32(self.speed)
             .as_micros()
             + self.offset_micros
     }
 
-    pub fn set_speed(&mut self, real_to_game: f32) {
+    pub fn speed(&self) -> f32 {
+        self.speed
+    }
+
+    pub fn set_speed(&mut self, speed: f32) {
         let new_baseline = Instant::now();
         self.offset_micros = self.get_micros_at(&new_baseline);
         self.baseline = new_baseline;
-        self.real_to_game = real_to_game;
+        self.speed = speed;
     }
 }


### PR DESCRIPTION
Without this the offset in clock is from the last Instant where the speed was changed, not the Instant where the game was saved.

This was resulting in loaded games having clock times well before the micros in plans.