### PR TITLE
fix (mountain): distance network can_visit applied on to position

### DIFF
--- a/mountain/src/network/distance.rs
+++ b/mountain/src/network/distance.rs
@@ -1,3 +1,5 @@
+use std::iter::empty;
+
 use commons::geometry::XY;
 use commons::grid::Grid;
 use commons::grid::OFFSETS_8;
@@ -16,12 +18,15 @@ impl<'a> InNetwork<XY<u32>> for DistanceNetwork<'a> {
         &'b self,
         to: &'b XY<u32>,
     ) -> Box<dyn Iterator<Item = network::model::Edge<XY<u32>>> + 'b> {
+        if !(self.can_visit)(to) {
+            return Box::new(empty());
+        }
+
         let iter = OFFSETS_8
             .iter()
             .flat_map(move |offset| self.piste.grid.offset(to, offset))
             .filter(|from| self.piste.grid.in_bounds(from))
             .filter(|from| self.piste.grid[from])
-            .filter(|from| (self.can_visit)(from))
             .map(move |from| Edge {
                 from,
                 to: *to,

--- a/mountain/src/systems/distance_cost_computer.rs
+++ b/mountain/src/systems/distance_cost_computer.rs
@@ -43,17 +43,19 @@ fn compute_costs(
         .filter(|position| piste.grid[*position])
         .collect::<HashSet<_>>();
 
-    let network = DistanceNetwork {
-        terrain,
-        piste,
-        can_visit: &|position| !exit_positions.contains(position),
-    };
-
     for Exit {
         id: exit_id,
         positions,
     } in exits
     {
+        let network = DistanceNetwork {
+            terrain,
+            piste,
+            can_visit: &|position| {
+                positions.contains(position) || !exit_positions.contains(position)
+            },
+        };
+
         let costs = compute_costs_for_targets(&network, positions);
         let coverage = costs.len() as f32
             / (piste_positions(piste).len() * DIRECTIONS.len() * (VELOCITY_LEVELS as usize + 1))


### PR DESCRIPTION
This meant skiers could get stuck in an exit after that exit had been closed since moving _from_ this position was forbidden.

We also need to make sure we can move to the targets, hence the `positions.contains(position)` clause.