### PR TITLE
refactor (mountain): renaming is_reserved_fn in SkiingNetwork

### DIFF
--- a/mountain/src/network/skiing.rs
+++ b/mountain/src/network/skiing.rs
@@ -26,7 +26,7 @@ const STOP_MAX_VELOCITY: f32 = 1.5;
 
 pub struct SkiingNetwork<'a> {
     pub terrain: &'a Grid<f32>,
-    pub is_reserved_fn: &'a dyn Fn(&XY<u32>) -> bool,
+    pub is_accessible_fn: &'a dyn Fn(&XY<u32>) -> bool,
     pub is_skiable_edge_fn: &'a dyn Fn(&State, &State) -> bool,
 }
 
@@ -77,7 +77,7 @@ impl<'a> SkiingNetwork<'a> {
     ) -> Option<Edge<State>> {
         let to_position = self.get_to_position(&from.position, &travel_direction)?;
 
-        if (self.is_reserved_fn)(&to_position) {
+        if !(self.is_accessible_fn)(&to_position) {
             return None;
         }
 
@@ -191,7 +191,7 @@ impl<'a> SkiingNetwork<'a> {
     fn get_poling_edge(&self, from: &State, velocity: &u8) -> Option<Edge<State>> {
         let to_position = self.get_to_position(&from.position, &from.travel_direction)?;
 
-        if (self.is_reserved_fn)(&to_position) {
+        if !(self.is_accessible_fn)(&to_position) {
             return None;
         }
 

--- a/mountain/src/systems/planner.rs
+++ b/mountain/src/systems/planner.rs
@@ -250,8 +250,8 @@ fn find_path(
 ) -> Option<Vec<Edge<State>>> {
     let network = SkiingNetwork {
         terrain,
-        is_reserved_fn: &|position| {
-            reservations[position]
+        is_accessible_fn: &|position| {
+            !reservations[position]
                 .values()
                 .any(|reservation| reservation.is_valid_at(micros))
         },

--- a/mountain/src/systems/skiing_network_computer.rs
+++ b/mountain/src/systems/skiing_network_computer.rs
@@ -92,7 +92,9 @@ fn compute_costs_and_basin_for_exit(
 ) -> (HashMap<State, u64>, HashSet<State>) {
     let network = SkiingNetwork {
         terrain,
-        is_reserved_fn: &|position| !targets.contains(position) && inaccessible.contains(position),
+        is_accessible_fn: &|position| {
+            targets.contains(position) || !inaccessible.contains(position)
+        },
         is_skiable_edge_fn: &|a, b| match (distance_costs.get(a), distance_costs.get(b)) {
             (Some(to), Some(from)) => to < from,
             _ => false,


### PR DESCRIPTION
fn was not always used to indicate reservations, and negative description was awkward