### PR TITLE
feat (terrain_gen)!:  heightmap_from_rises output no longer normalized

### DIFF
--- a/mountain/src/init/terrain.rs
+++ b/mountain/src/init/terrain.rs
@@ -6,11 +6,11 @@ use terrain_gen::heightmap_from_rises;
 pub fn generate_heightmap() -> Grid<f32> {
     let power = 9;
     let weights = (0..power + 1)
-        .map(|i| 1.0f32 / 1.125f32.powf((power - i) as f32))
+        .map(|i| 1.0f32 / 1.4f32.powf((power - i) as f32))
         .collect::<Vec<_>>();
     let rises = simplex_noise(power, 1987, &weights)
         .normalize()
         .map(|_, z| (0.5 - z).abs() / 0.5);
 
-    heightmap_from_rises(&rises, |xy| rises.is_border(xy)).map(|_, v| v * 128.0)
+    heightmap_from_rises(&rises, |xy| xy.x == 0 && xy.y == 0)
 }

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -49,6 +49,7 @@ use crate::systems::{
 
 fn main() {
     let components = get_components();
+    let max_z = components.terrain.max();
 
     let engine = glium_backend::engine::GliumEngine::new(
         Game {
@@ -220,7 +221,7 @@ fn main() {
                 },
                 scale: isometric::ScaleParameters {
                     zoom: 2.0,
-                    z_max: 1.0 / 128.0,
+                    z_max: 1.0 / max_z,
                     viewport: Rectangle {
                         width: 512,
                         height: 512,

--- a/terrain_gen/src/heightmap_from_rises/mod.rs
+++ b/terrain_gen/src/heightmap_from_rises/mod.rs
@@ -52,7 +52,7 @@ where
         }
     }
 
-    out.normalize()
+    out
 }
 
 struct HeapElement {
@@ -101,6 +101,7 @@ mod tests {
 
         // when
         let heightmap = heightmap_from_rises(&rises, |xy| rises.is_border(xy));
+        let heightmap = heightmap.normalize();
 
         // then
         let temp_path = temp_dir().join("test.png");

--- a/terrain_gen/src/heightmap_from_rises/with_valleys.rs
+++ b/terrain_gen/src/heightmap_from_rises/with_valleys.rs
@@ -23,6 +23,7 @@ where
     let parameters = parameters.borrow();
 
     let heightmap = heightmap_from_rises(rises, &parameters.origin_fn);
+    let heightmap = heightmap.normalize();
     let rain = heightmap.rain();
 
     let valley_rises = rises.map(|xy, z| {
@@ -35,6 +36,7 @@ where
     let valley_heightmap = heightmap_from_rises(&valley_rises, |xy| {
         heightmap[xy] <= parameters.height_threshold
     });
+    let valley_heightmap = valley_heightmap.normalize();
 
     let valley_scale = Scale::new((0.0, 1.0), (parameters.height_threshold, 1.0));
     heightmap.map(|xy, z| {


### PR DESCRIPTION
This allows us to control the slope of output heightmaps by controlling the values in rises. For example, if the max value in rises in 1.0 we can guarantee that the heightmap from heightmap_from_rises will have no slope > 1.0. This means that heightmaps generated with noise generated from different seeds look more consistent than they did before.