### PR TITLE
fix (mountain): some pistes were impossible to grade

### DIFF
--- a/mountain/src/utils/computer/piste_ability.rs
+++ b/mountain/src/utils/computer/piste_ability.rs
@@ -70,8 +70,6 @@ fn compute_ability(
         for target in targets.iter() {
             if let Some(ability) = costs.min_ability(entrance, target) {
                 abilities.push(ability);
-            } else {
-                return None;
             }
         }
     }


### PR DESCRIPTION
In this scenario:

Entrance A
Exit A
Entrance B (much lower)
Exit B

Then it was impossible to route from Entrance B to Exit A due to the slope. This meant the piste would be left with no ability.

It seems to work better to take the max ability over all routes that are at least possible for experts.