### PR TITLE
feat (mountain): selection with rotated rectangles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line_drawing"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1478a313008a3e6c8149995e90a99ee9094034b5c5c3da1eeb81183cb61d1d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +994,7 @@ dependencies = [
  "bincode",
  "commons",
  "engine",
+ "line_drawing",
  "nalgebra",
  "network",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 bincode = "1"
 image = "0"
 glium = "0"
+line_drawing = "1"
 maplit = "1"
 nalgebra = "0"
 num = "0"

--- a/mountain/Cargo.toml
+++ b/mountain/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 bincode = { workspace = true }
 commons = { path = "../commons" }
 engine = { path = "../engine" }
+line_drawing = { workspace = true }
 nalgebra = { workspace = true }
 network = { path = "../network" }
 rand = { workspace = true }

--- a/mountain/src/handlers/entrance_builder.rs
+++ b/mountain/src/handlers/entrance_builder.rs
@@ -46,7 +46,7 @@ impl Handler {
         if !self.binding.binds_event(event) {
             return;
         }
-        let (Some(origin), Some(grid)) = (selection.origin, &selection.grid) else {
+        let (Some(&origin), Some(grid)) = (selection.cells.first(), &selection.grid) else {
             return;
         };
 

--- a/mountain/src/handlers/piste_builder.rs
+++ b/mountain/src/handlers/piste_builder.rs
@@ -36,7 +36,7 @@ impl Handler {
             return;
         }
 
-        let (Some(origin), Some(grid)) = (selection.origin, &selection.grid) else {
+        let (Some(origin), Some(grid)) = (selection.cells.first(), &selection.grid) else {
             return;
         };
 

--- a/mountain/src/handlers/selection.rs
+++ b/mountain/src/handlers/selection.rs
@@ -10,11 +10,17 @@ use super::*;
 pub struct Handler {
     pub cells: Vec<XY<u32>>,
     pub grid: Option<OriginGrid<bool>>,
-    pub binding: Binding,
+    pub binding: Bindings,
+}
+
+pub struct Bindings {
+    pub first_cell: Binding,
+    pub second_cell: Binding,
+    pub clear: Binding,
 }
 
 impl Handler {
-    pub fn new(binding: Binding) -> Handler {
+    pub fn new(binding: Bindings) -> Handler {
         Handler {
             cells: Vec::with_capacity(3),
             grid: None,
@@ -34,13 +40,13 @@ impl Handler {
             self.update_last_cell(terrain, mouse_xy, graphics)
         }
 
-        if self.binding.binds_event(event) {
-            if self.cells.is_empty() {
-                self.add_cell(terrain, mouse_xy, graphics);
-                self.add_cell(terrain, mouse_xy, graphics);
-            } else {
-                self.clear_selection();
-            }
+        if self.binding.clear.binds_event(event) && !self.cells.is_empty() {
+            self.clear_selection();
+        } else if self.binding.first_cell.binds_event(event) && self.cells.is_empty() {
+            self.add_cell(terrain, mouse_xy, graphics);
+            self.add_cell(terrain, mouse_xy, graphics);
+        } else if self.binding.second_cell.binds_event(event) && self.cells.len() == 2 {
+            self.add_cell(terrain, mouse_xy, graphics);
         }
 
         let new_grid = &self.grid;

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -142,9 +142,19 @@ fn main() {
                         state: ButtonState::Pressed,
                     },
                 },
-                selection: selection::Handler::new(Binding::Single {
-                    button: Button::Mouse(MouseButton::Right),
-                    state: ButtonState::Pressed,
+                selection: selection::Handler::new(selection::Bindings {
+                    first_cell: Binding::Single {
+                        button: Button::Mouse(MouseButton::Right),
+                        state: ButtonState::Pressed,
+                    },
+                    second_cell: Binding::Single {
+                        button: Button::Mouse(MouseButton::Right),
+                        state: ButtonState::Released,
+                    },
+                    clear: Binding::Single {
+                        button: Button::Mouse(MouseButton::Right),
+                        state: ButtonState::Pressed,
+                    },
                 }),
                 yaw: yaw::Handler::new(yaw::Parameters {
                     initial_angle: 5,


### PR DESCRIPTION
You can can now select using a rotated angle by dragging a line before releasing the right mouse button. The line is used as the basis for the rectangle.