### PR TITLE
refactor (mountain): removing redundant check

### DIFF
--- a/mountain/src/handlers/selection.rs
+++ b/mountain/src/handlers/selection.rs
@@ -165,10 +165,6 @@ impl Handler {
     fn compute_border_1(&self) -> Option<XY<u32>> {
         let cells = &self.cells;
 
-        if cells[0] == cells[2] {
-            return Some(cells[1]);
-        }
-
         // Case where user did not drag
         let to = if cells[0] == cells[1] {
             // Default is a grid aligned to the x-axis


### PR DESCRIPTION
No longer needed since this case is handled in `project_point_onto_line`.