### PR TITLE
feat (mountain): MapNetwork considers piste ability

### DIFF
--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -674,6 +674,7 @@ impl EventHandler for Game {
                 carousels: &self.components.carousels,
                 entrances: &self.components.entrances,
                 costs: &self.components.costs,
+                abilities: &self.components.abilities,
                 ability: Ability::Advanced,
             };
             for lift in self.components.lifts.keys() {

--- a/mountain/src/network/target.rs
+++ b/mountain/src/network/target.rs
@@ -20,6 +20,7 @@ pub struct TargetNetwork<'a> {
     pub carousels: &'a HashMap<usize, Carousel>,
     pub entrances: &'a HashMap<usize, Entrance>,
     pub costs: &'a HashMap<usize, Costs>,
+    pub abilities: &'a HashMap<usize, Ability>,
     pub ability: Ability,
 }
 
@@ -46,6 +47,7 @@ impl<'a> TargetNetwork<'a> {
         self.piste_map
             .offsets(position, &CORNERS_INVERSE)
             .flat_map(|corner| self.piste_map[corner])
+            .filter(|piste_id| self.abilities[piste_id] <= self.ability)
             .collect::<HashSet<_>>()
     }
 


### PR DESCRIPTION
This is important because e.g. a lift might lead to a point between two pistes. If one piste is within the skiers ability and the other is not, clearly we should only include edges using the first piste.