### PR TITLE
feat (mountain): removing invalid targets

### DIFF
--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -607,7 +607,7 @@ impl EventHandler for Game {
             global_costs: &self.components.global_costs,
             costs: &self.components.costs,
             open: &self.components.open,
-            global_targets: &self.components.global_targets,
+            global_targets: &mut self.components.global_targets,
             targets: &mut self.components.targets,
         });
 


### PR DESCRIPTION
Though target removal is implemented here, the only way it will happen in practice is when a dead end is created. Otherwise, when skiers encountered a closed lift/entrance, they will simply choose another path - even if this leads away from the goal, it will still have a cost to the goal and so the skier thinks they can reach it.

We need to update the global costs each time a piste or entrance is opened/closed.