### PR TITLE
fix (mountain): invalid global target was not always cleared

### DIFF
--- a/mountain/src/systems/target_setter.rs
+++ b/mountain/src/systems/target_setter.rs
@@ -27,6 +27,8 @@ pub fn run(
         targets,
     }: Parameters<'_>,
 ) {
+    let default_global_costs = HashMap::default();
+
     for (skier_id, plan) in plans {
         let Plan::Stationary(state) = plan else {
             continue;
@@ -52,9 +54,9 @@ pub fn run(
             continue;
         };
 
-        let Some(global_costs) = global_costs.costs(*global_target, *skier_ability) else {
-            continue;
-        };
+        let global_costs = global_costs
+            .costs(*global_target, *skier_ability)
+            .unwrap_or(&default_global_costs);
 
         let stationary_state = state.stationary();
 


### PR DESCRIPTION
global target was not cleared if there were no global costs for that target