### PR TITLE
refector (mountain): removing support for entrance onto many pistes

### DIFF
--- a/mountain/src/handlers/piste_computer.rs
+++ b/mountain/src/handlers/piste_computer.rs
@@ -29,7 +29,7 @@ pub struct Parameters<'a> {
     pub piste_map: &'a Grid<Option<usize>>,
     pub lifts: &'a HashMap<usize, Lift>,
     pub gates: &'a HashMap<usize, Gate>,
-    pub entrances: &'a mut HashMap<usize, Vec<Entrance>>,
+    pub entrances: &'a mut HashMap<usize, Entrance>,
     pub exits: &'a mut HashMap<usize, Vec<Exit>>,
     pub reservations: &'a Grid<HashMap<usize, Reservation>>,
     pub costs: &'a mut HashMap<usize, Costs<State>>,

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -373,7 +373,7 @@ pub struct Components {
     cars: HashMap<usize, Car>,
     carousels: HashMap<usize, Carousel>,
     gates: HashMap<usize, Gate>,
-    entrances: HashMap<usize, Vec<Entrance>>,
+    entrances: HashMap<usize, Entrance>,
     exits: HashMap<usize, Vec<Exit>>,
     abilities: HashMap<usize, Ability>,
     #[serde(skip)]

--- a/mountain/src/model/entrance.rs
+++ b/mountain/src/model/entrance.rs
@@ -5,6 +5,6 @@ use crate::model::skiing::State;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entrance {
-    pub id: usize,
+    pub destination_piste_id: usize,
     pub stationary_states: HashSet<State>,
 }

--- a/mountain/src/utils/computer/piste_ability.rs
+++ b/mountain/src/utils/computer/piste_ability.rs
@@ -19,22 +19,7 @@ pub fn compute_piste(
         return;
     };
 
-    let Some(exits) = exits.get(piste_id) else {
-        return;
-    };
-
-    if let Some(ability) = compute_ability(piste_id, costs, entrances, exits) {
-        abilities.insert(*piste_id, ability);
-    }
-}
-
-fn compute_ability(
-    piste_id: &usize,
-    costs: &Costs<State>,
-    entrances: &HashMap<usize, Entrance>,
-    exits: &[Exit],
-) -> Option<Ability> {
-    entrances
+    let entrances = entrances
         .values()
         .filter(
             |Entrance {
@@ -42,6 +27,24 @@ fn compute_ability(
                  ..
              }| destination_piste_id == piste_id,
         )
+        .collect::<Vec<_>>();
+
+    let Some(exits) = exits.get(piste_id) else {
+        return;
+    };
+
+    if let Some(ability) = compute_ability(costs, &entrances, exits) {
+        abilities.insert(*piste_id, ability);
+    }
+}
+
+fn compute_ability(
+    costs: &Costs<State>,
+    entrances: &[&Entrance],
+    exits: &[Exit],
+) -> Option<Ability> {
+    entrances
+        .iter()
         .flat_map(
             |Entrance {
                  stationary_states: states,

--- a/mountain/src/utils/computer/piste_ability.rs
+++ b/mountain/src/utils/computer/piste_ability.rs
@@ -9,7 +9,7 @@ use crate::model::skiing::State;
 pub fn compute_piste(
     piste_id: &usize,
     costs: &HashMap<usize, Costs<State>>,
-    entrances: &HashMap<usize, Vec<Entrance>>,
+    entrances: &HashMap<usize, Entrance>,
     exits: &HashMap<usize, Vec<Exit>>,
     abilities: &mut HashMap<usize, Ability>,
 ) {
@@ -19,26 +19,29 @@ pub fn compute_piste(
         return;
     };
 
-    let Some(entrances) = entrances.get(piste_id) else {
-        return;
-    };
-
     let Some(exits) = exits.get(piste_id) else {
         return;
     };
 
-    if let Some(ability) = compute_ability(costs, entrances, exits) {
+    if let Some(ability) = compute_ability(piste_id, costs, entrances, exits) {
         abilities.insert(*piste_id, ability);
     }
 }
 
 fn compute_ability(
+    piste_id: &usize,
     costs: &Costs<State>,
-    entrances: &[Entrance],
+    entrances: &HashMap<usize, Entrance>,
     exits: &[Exit],
 ) -> Option<Ability> {
     entrances
-        .iter()
+        .values()
+        .filter(
+            |Entrance {
+                 destination_piste_id,
+                 ..
+             }| destination_piste_id == piste_id,
+        )
         .flat_map(
             |Entrance {
                  stationary_states: states,


### PR DESCRIPTION
Entrances map in Components is now keyed by lift/gate ID, not piste ID