### PR TITLE
feat (mountain): global target setting improvements

### DIFF
--- a/mountain/src/handlers/skier_debugger.rs
+++ b/mountain/src/handlers/skier_debugger.rs
@@ -15,6 +15,7 @@ pub struct Parameters<'a> {
     pub mouse_xy: &'a Option<XY<u32>>,
     pub reservations: &'a Grid<HashMap<usize, Reservation>>,
     pub plans: &'a HashMap<usize, Plan>,
+    pub locations: &'a HashMap<usize, usize>,
     pub targets: &'a HashMap<usize, usize>,
     pub global_targets: &'a HashMap<usize, usize>,
     pub graphics: &'a mut dyn engine::graphics::Graphics,
@@ -28,6 +29,7 @@ impl Handler {
             mouse_xy,
             reservations,
             plans,
+            locations,
             targets,
             global_targets,
             graphics,
@@ -45,6 +47,7 @@ impl Handler {
 
         for (id, _) in reservations[mouse_position].iter() {
             println!("ID = {:?}", id);
+            println!("Location = {:?}", locations.get(id));
             println!("Target = {:?}", targets.get(id));
             println!("Global target = {:?}", global_targets.get(id));
             println!("Plan = {:?}", plans.get(id));

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -587,6 +587,7 @@ impl EventHandler for Game {
                 mouse_xy: &self.mouse_xy,
                 reservations: &self.components.reservations,
                 plans: &self.components.plans,
+                locations: &self.components.locations,
                 targets: &self.components.targets,
                 global_targets: &self.components.global_targets,
                 graphics,

--- a/mountain/src/systems/global_target_setter.rs
+++ b/mountain/src/systems/global_target_setter.rs
@@ -64,16 +64,7 @@ pub fn run(
             .flat_map(|(piste_target, _)| {
                 global_costs
                     .targets_reachable_from_node(piste_target, skier_ability)
-                    .filter(|(target, _)| valid_global_targets.contains(target)) // only target lifts
-                    .filter(|&(_, cost)| *cost != 0) // global target must require moving
-                    .filter(move |(new_target, _)| {
-                        // will not get stuck
-                        global_costs
-                            .targets_reachable_from_node(new_target, skier_ability)
-                            .filter(|&(_, cost)| *cost != 0)
-                            .count()
-                            != 0
-                    })
+                    .filter(|(target, _)| valid_global_targets.contains(target))
             })
             .map(|(global_target, _)| global_target)
             .collect::<Vec<_>>();

--- a/mountain/src/utils/computer/global_costs.rs
+++ b/mountain/src/utils/computer/global_costs.rs
@@ -36,12 +36,6 @@ pub fn compute_global_costs(
 ) {
     *global_costs = Costs::new();
 
-    let targets = entrances
-        .keys()
-        .filter(|target| open.contains(target))
-        .copied()
-        .collect::<HashSet<_>>();
-
     for ability in ABILITIES {
         let network = GlobalNetwork {
             piste_map,
@@ -52,6 +46,27 @@ pub fn compute_global_costs(
             abilities,
             ability,
         };
+
+        let targets = entrances
+            .iter()
+            .filter(|&(target, _)| open.contains(target))
+            .filter(
+                |&(
+                    _,
+                    Entrance {
+                        destination_piste_id,
+                        ..
+                    },
+                )| {
+                    abilities
+                        .get(destination_piste_id)
+                        .map(|&piste_ability| piste_ability <= ability)
+                        .unwrap_or_default()
+                },
+            )
+            .map(|(target, _)| target)
+            .copied()
+            .collect::<HashSet<_>>();
 
         let network = MaterializedInNetwork::from_out_network(&network, &targets);
 


### PR DESCRIPTION
The error prone logic for preventing stuck skiers was removed, as was the restriction on skiers targeting a zero cost target. This allows skiers to target e.g. a lift that starts and ends on the same slope as them.

To stop skiers ending up on a piste beyond their ability, computer::global_cost now makes sure we don't create nodes for entrances onto pistes exceeding their ability.