### PR TITLE
fix: colors were too dark following dependency update

### DIFF
--- a/engine/src/glium_backend/graphics/programs.rs
+++ b/engine/src/glium_backend/graphics/programs.rs
@@ -11,31 +11,31 @@ pub struct Programs {
 impl Programs {
     pub fn new(facade: &dyn glium::backend::Facade) -> Result<Programs, Box<dyn Error>> {
         Ok(Programs {
-            primitive: glium::Program::from_source(
+            primitive: from_source(
                 facade,
                 include_str!("../../graphics/shaders/primitive.vert"),
                 include_str!("../../graphics/shaders/primitive.frag"),
                 None,
             )?,
-            overlay_primitive: glium::Program::from_source(
+            overlay_primitive: from_source(
                 facade,
                 include_str!("../../graphics/shaders/overlay_primitive.vert"),
                 include_str!("../../graphics/shaders/overlay_primitive.frag"),
                 None,
             )?,
-            instanced_primitive: glium::Program::from_source(
+            instanced_primitive: from_source(
                 facade,
                 include_str!("../../graphics/shaders/instanced_primitive.vert"),
                 include_str!("../../graphics/shaders/instanced_primitive.frag"),
                 None,
             )?,
-            screen: glium::Program::from_source(
+            screen: from_source(
                 facade,
                 include_str!("../../graphics/shaders/screen.vert"),
                 include_str!("../../graphics/shaders/screen.frag"),
                 None,
             )?,
-            billboard: glium::Program::from_source(
+            billboard: from_source(
                 facade,
                 include_str!("../../graphics/shaders/billboard.vert"),
                 include_str!("../../graphics/shaders/billboard.frag"),
@@ -43,4 +43,29 @@ impl Programs {
             )?,
         })
     }
+}
+
+// This replicates glium::Program::from_source with outputs_srgb: false
+pub fn from_source<'a, F>(
+    facade: &F,
+    vertex_shader: &'a str,
+    fragment_shader: &'a str,
+    geometry_shader: Option<&'a str>,
+) -> Result<glium::Program, glium::ProgramCreationError>
+where
+    F: glium::backend::Facade + ?Sized,
+{
+    glium::Program::new(
+        facade,
+        glium::program::ProgramCreationInput::SourceCode {
+            vertex_shader,
+            fragment_shader,
+            geometry_shader,
+            tessellation_control_shader: None,
+            tessellation_evaluation_shader: None,
+            transform_feedback_varyings: None,
+            outputs_srgb: false,
+            uses_point_size: false,
+        },
+    )
 }


### PR DESCRIPTION
Longer term it would be better to use `outputs_srgb: true` so glium does the SRGB conversion instead of having to apply it manually to each color.