### PR TITLE
fix (mountain): selection frozen after changing mode

### DIFF
--- a/mountain/src/controllers/building_builder.rs
+++ b/mountain/src/controllers/building_builder.rs
@@ -8,10 +8,10 @@ use rand::seq::SliceRandom;
 use rand::thread_rng;
 
 use crate::controllers::Result::{self, Action, NoAction};
-use crate::handlers::selection;
 use crate::model::ability::Ability;
 use crate::model::building::{Building, Roof, Window};
 use crate::model::direction::Direction;
+use crate::model::selection::Selection;
 use crate::model::skier::{Clothes, Color, Skier};
 use crate::services::id_allocator;
 use crate::systems::{building_artist, messenger, tree_artist, window_artist};
@@ -57,7 +57,7 @@ pub enum State {
 }
 
 pub struct SelectParameters<'a> {
-    pub selection: &'a mut selection::Handler,
+    pub selection: &'a mut Selection,
     pub id_allocator: &'a mut id_allocator::Service,
     pub buildings: &'a mut HashMap<usize, Building>,
     pub tree_artist: &'a mut tree_artist::System,
@@ -134,7 +134,7 @@ impl Controller {
 
         // clearing selection
 
-        selection.clear_selection();
+        selection.cells.clear();
 
         self.state = State::Editing { building_id };
         Action

--- a/mountain/src/controllers/door_builder.rs
+++ b/mountain/src/controllers/door_builder.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use commons::geometry::{xy, XYRectangle, XY};
 use commons::grid::Grid;
 
-use crate::handlers::selection;
 use crate::model::building::Building;
 
 use crate::model::direction::{Direction, DIRECTIONS};
@@ -12,6 +11,7 @@ use crate::model::door::Door;
 use crate::controllers::Result::{self, Action, NoAction};
 use crate::model::entrance::Entrance;
 use crate::model::piste::Piste;
+use crate::model::selection::Selection;
 use crate::model::skiing::State;
 use crate::services::id_allocator;
 use crate::systems::messenger;
@@ -19,7 +19,7 @@ use crate::systems::messenger;
 pub struct Parameters<'a> {
     pub pistes: &'a HashMap<usize, Piste>,
     pub terrain: &'a Grid<f32>,
-    pub selection: &'a mut selection::Handler,
+    pub selection: &'a mut Selection,
     pub buildings: &'a HashMap<usize, Building>,
     pub id_allocator: &'a mut id_allocator::Service,
     pub doors: &'a mut HashMap<usize, Door>,
@@ -44,14 +44,14 @@ pub fn trigger(
     };
     if grid.width() != 1 && grid.height() != 1 {
         messenger.send("Door must be 1 wide or 1 high");
-        selection.clear_selection();
+        selection.cells.clear();
         return NoAction;
     }
 
     let longest_side_cell_count = grid.width().max(grid.height());
     if longest_side_cell_count < 2 {
         messenger.send("Door must be at least 2 wide or 2 high");
-        selection.clear_selection();
+        selection.cells.clear();
         return NoAction;
     }
 
@@ -72,13 +72,13 @@ pub fn trigger(
             "Door must contain {} postions from the same building",
             longest_side_position_count
         ));
-        selection.clear_selection();
+        selection.cells.clear();
         return NoAction;
     };
 
     if building.under_construction {
         messenger.send("Door cannot be added to building under construction");
-        selection.clear_selection();
+        selection.cells.clear();
         return NoAction;
     }
 
@@ -95,7 +95,7 @@ pub fn trigger(
             "Door must contain {} postions from the same piste",
             longest_side_position_count
         ));
-        selection.clear_selection();
+        selection.cells.clear();
         return NoAction;
     };
 
@@ -126,7 +126,7 @@ pub fn trigger(
         },
     );
 
-    selection.clear_selection();
+    selection.cells.clear();
 
     Action
 }

--- a/mountain/src/controllers/gate_builder.rs
+++ b/mountain/src/controllers/gate_builder.rs
@@ -4,12 +4,12 @@ use commons::geometry::{xy, XYRectangle};
 use commons::grid::Grid;
 
 use crate::controllers::Result::{self, Action, NoAction};
-use crate::handlers::selection;
 use crate::model::direction::DIRECTIONS;
 use crate::model::entrance::Entrance;
 use crate::model::exit::Exit;
 use crate::model::gate::Gate;
 use crate::model::reservation::Reservation;
+use crate::model::selection::Selection;
 use crate::model::skiing::State;
 use crate::services::id_allocator;
 use crate::systems::{messenger, terrain_artist};
@@ -17,7 +17,7 @@ use crate::systems::{messenger, terrain_artist};
 pub struct Parameters<'a> {
     pub terrain: &'a Grid<f32>,
     pub piste_map: &'a Grid<Option<usize>>,
-    pub selection: &'a mut selection::Handler,
+    pub selection: &'a mut Selection,
     pub terrain_artist: &'a mut terrain_artist::System,
     pub id_allocator: &'a mut id_allocator::Service,
     pub gates: &'a mut HashMap<usize, Gate>,
@@ -52,8 +52,7 @@ pub fn trigger(
     };
 
     // clearing selection
-
-    selection.clear_selection();
+    selection.cells.clear();
     terrain_artist.update_overlay(rectangle);
 
     // create gate

--- a/mountain/src/controllers/piste_builder.rs
+++ b/mountain/src/controllers/piste_builder.rs
@@ -6,9 +6,9 @@ use commons::grid::{Grid, CORNERS_INVERSE};
 use commons::origin_grid::OriginGrid;
 
 use crate::controllers::Result::{self, Action, NoAction};
-use crate::handlers::selection;
 
 use crate::model::piste::{self, Piste};
+use crate::model::selection::Selection;
 use crate::services::id_allocator;
 use crate::systems::{terrain_artist, tree_artist};
 
@@ -20,7 +20,7 @@ pub struct Controller {
 pub struct Parameters<'a> {
     pub pistes: &'a mut HashMap<usize, Piste>,
     pub piste_map: &'a mut Grid<Option<usize>>,
-    pub selection: &'a mut selection::Handler,
+    pub selection: &'a mut Selection,
     pub terrain_artist: &'a mut terrain_artist::System,
     pub tree_artist: &'a mut tree_artist::System,
     pub id_allocator: &'a mut id_allocator::Service,
@@ -102,7 +102,7 @@ impl Controller {
 
         // clearing selection
 
-        selection.clear_selection();
+        selection.cells.clear();
 
         Action
     }

--- a/mountain/src/controllers/piste_eraser.rs
+++ b/mountain/src/controllers/piste_eraser.rs
@@ -5,9 +5,9 @@ use commons::grid::{Grid, CORNERS_INVERSE};
 use commons::origin_grid::OriginGrid;
 
 use crate::controllers::Result::{self, Action, NoAction};
-use crate::handlers::selection;
 
 use crate::model::piste::Piste;
+use crate::model::selection::Selection;
 use crate::systems::{terrain_artist, tree_artist};
 
 pub struct Controller {
@@ -17,7 +17,7 @@ pub struct Controller {
 pub struct Parameters<'a> {
     pub pistes: &'a mut HashMap<usize, Piste>,
     pub piste_map: &'a mut Grid<Option<usize>>,
-    pub selection: &'a mut selection::Handler,
+    pub selection: &'a mut Selection,
     pub terrain_artist: &'a mut terrain_artist::System,
     pub tree_artist: &'a mut tree_artist::System,
 }
@@ -97,7 +97,7 @@ impl Controller {
 
         // clearing selection
 
-        selection.clear_selection();
+        selection.cells.clear();
 
         Action
     }

--- a/mountain/src/gui.rs
+++ b/mountain/src/gui.rs
@@ -211,7 +211,7 @@ pub fn run(
 
     for (i, &clicked) in mode_button_clicked.iter().enumerate() {
         if clicked {
-            game.handlers.selection.clear_selection();
+            game.components.selection.cells.clear();
             let config = &MODE_BUTTONS[i];
             if build_mode == config.build_mode {
                 game.components.services.mode.set_mode(mode::Mode::None);

--- a/mountain/src/gui.rs
+++ b/mountain/src/gui.rs
@@ -211,12 +211,17 @@ pub fn run(
 
     for (i, &clicked) in mode_button_clicked.iter().enumerate() {
         if clicked {
-            game.components.selection.cells.clear();
             let config = &MODE_BUTTONS[i];
             if build_mode == config.build_mode {
-                game.components.services.mode.set_mode(mode::Mode::None);
+                game.components
+                    .services
+                    .mode
+                    .set_mode(mode::Mode::None, &mut game.components.selection);
             } else {
-                game.components.services.mode.set_mode(config.build_mode);
+                game.components
+                    .services
+                    .mode
+                    .set_mode(config.build_mode, &mut game.components.selection);
             };
         }
     }

--- a/mountain/src/handlers/mode.rs
+++ b/mountain/src/handlers/mode.rs
@@ -1,3 +1,4 @@
+use crate::model::selection::Selection;
 use crate::services::mode::Mode;
 use crate::{services, Bindings};
 
@@ -5,13 +6,14 @@ pub fn handle(
     event: &engine::events::Event,
     bindings: &Bindings,
     service: &mut services::mode::Service,
+    selection: &mut Selection,
 ) {
     for (&mode, binding) in bindings.mode.iter() {
         if binding.binds_event(event) {
             if service.mode() == mode {
-                service.set_mode(Mode::None);
+                service.set_mode(Mode::None, selection);
             } else {
-                service.set_mode(mode);
+                service.set_mode(mode, selection);
             }
             return;
         }

--- a/mountain/src/handlers/selection.rs
+++ b/mountain/src/handlers/selection.rs
@@ -1,11 +1,8 @@
-use commons::geometry::{project_point_onto_line, xy, Line, XYRectangle, XY, XYZ};
-use commons::grid::{Grid, OFFSETS_4};
-use commons::origin_grid::OriginGrid;
+use commons::geometry::{xy, XY, XYZ};
+use commons::grid::Grid;
 use engine::binding::Binding;
-use line_drawing::Bresenham;
 
 use crate::model::selection::Selection;
-use crate::systems::terrain_artist;
 
 use super::*;
 
@@ -19,7 +16,6 @@ pub struct Parameters<'a> {
     pub terrain: &'a Grid<f32>,
     pub selection: &'a mut Selection,
     pub graphics: &'a mut dyn engine::graphics::Graphics,
-    pub terrain_artist: &'a mut terrain_artist::System,
 }
 
 pub struct Bindings {
@@ -44,7 +40,6 @@ impl Handler {
             terrain,
             selection,
             graphics,
-            terrain_artist,
         }: Parameters<'_>,
     ) {
         if let Event::MouseMoved(mouse_xy) = event {
@@ -64,19 +59,6 @@ impl Handler {
             self.add_cell(terrain, mouse_xy, &mut selection.cells, graphics);
         } else if bindings.second_cell.binds_event(event) && selection.cells.len() == 2 {
             self.add_cell(terrain, mouse_xy, &mut selection.cells, graphics);
-        }
-
-        let previous_grid = selection.grid.clone();
-
-        self.rasterize(terrain, selection);
-
-        let new_grid = &selection.grid;
-        if previous_grid != *new_grid {
-            previous_grid
-                .iter()
-                .chain(new_grid.iter())
-                .flat_map(|grid| grid.rectangle())
-                .for_each(|rectangle| terrain_artist.update_overlay(rectangle));
         }
     }
 
@@ -108,101 +90,6 @@ impl Handler {
             }
         }
     }
-
-    fn rasterize(&mut self, terrain: &Grid<f32>, selection: &mut Selection) {
-        selection.grid = None;
-
-        let cells = &selection.cells;
-        if cells.len() < 2 {
-            return;
-        }
-
-        // Computing border
-
-        let mut border = Vec::with_capacity(5);
-
-        if cells.len() == 2 {
-            border.push(cells[0]);
-            border.push(cells[1]);
-        } else if cells.len() == 3 {
-            border.push(cells[0]);
-
-            let Some(border_1) = self.compute_border_1(&selection.cells) else {
-                return;
-            };
-            if border_1.x > terrain.width() - 2 || border_1.y > terrain.height() {
-                return;
-            }
-            border.push(border_1);
-
-            border.push(cells[2]);
-
-            let border_3 = to_xy_i32(&border[2]) - (to_xy_i32(&border[1]) - to_xy_i32(&border[0]));
-            if border_3.x < 0 || border_3.y < 0 {
-                return;
-            }
-            let border_3 = xy(border_3.x as u32, border_3.y as u32);
-            if border_3.x > terrain.width() - 2 || border_3.y > terrain.height() {
-                return;
-            }
-            border.push(border_3);
-
-            // Adding fifth cell so final line is picked up by windows(2) below
-            border.push(cells[0]);
-        }
-
-        // Creating grid
-
-        let mut grid = OriginGrid::from_rectangle(
-            XYRectangle {
-                from: xy(
-                    border.iter().map(|point| point.x).min().unwrap(),
-                    border.iter().map(|point| point.y).min().unwrap(),
-                ),
-                to: xy(
-                    border.iter().map(|point| point.x).max().unwrap(),
-                    border.iter().map(|point| point.y).max().unwrap(),
-                ),
-            },
-            false,
-        );
-
-        // Rasterizing
-
-        for pair in border.windows(2) {
-            rasterize_line(&mut grid, &pair[0], &pair[1]);
-        }
-        let filled = fill_cells_inaccessible_from_border(&grid);
-
-        selection.grid = Some(filled)
-    }
-
-    fn compute_border_1(&self, cells: &[XY<u32>]) -> Option<XY<u32>> {
-        // Case where user did not drag
-        let to = if cells[0] == cells[1] {
-            // Default is a grid aligned to the x-axis
-            cells[0] + xy(1, 0)
-        } else {
-            cells[1]
-        };
-
-        let out = project_point_onto_line(
-            to_xy_f32(&cells[2]),
-            Line {
-                from: to_xy_f32(&cells[0]),
-                to: to_xy_f32(&to),
-            },
-        );
-
-        let Ok(out) = out else {
-            return None;
-        };
-        let out = xy(out.x.round(), out.y.round());
-        if out.x < 0.0 || out.y < 0.0 {
-            return None;
-        }
-        Some(xy(out.x as u32, out.y as u32))
-    }
 }
 
 fn selected_cell(
@@ -218,42 +105,4 @@ fn selected_cell(
         (y.floor() as u32).min(terrain.height() - 2),
     );
     Some(cell)
-}
-
-fn to_xy_f32(XY { x, y }: &XY<u32>) -> XY<f32> {
-    xy(*x as f32, *y as f32)
-}
-
-fn to_xy_i32(XY { x, y }: &XY<u32>) -> XY<i32> {
-    xy(*x as i32, *y as i32)
-}
-
-fn rasterize_line(grid: &mut OriginGrid<bool>, from: &XY<u32>, to: &XY<u32>) {
-    for (x, y) in Bresenham::new((from.x as i32, from.y as i32), (to.x as i32, to.y as i32)) {
-        grid[xy(x as u32, y as u32)] = true;
-    }
-}
-
-fn fill_cells_inaccessible_from_border(grid: &OriginGrid<bool>) -> OriginGrid<bool> {
-    let border = grid
-        .iter()
-        .filter(|xy| !grid[xy])
-        .filter(|xy| grid.is_border(xy));
-
-    let mut out = grid.map(|_, _| true);
-    let mut queue = Vec::with_capacity((grid.width() * grid.height()) as usize);
-    for cell in border {
-        out[cell] = false;
-        queue.push(cell);
-    }
-
-    while let Some(cell) = queue.pop() {
-        for neighbour in grid.offsets(cell, &OFFSETS_4).collect::<Vec<_>>() {
-            if !grid[neighbour] && out[neighbour] {
-                out[neighbour] = false;
-                queue.push(neighbour);
-            }
-        }
-    }
-    out
 }

--- a/mountain/src/handlers/selection.rs
+++ b/mountain/src/handlers/selection.rs
@@ -38,12 +38,12 @@ impl Handler {
             bindings,
             mouse_xy,
             terrain,
-            selection,
+            selection: Selection { cells, .. },
             graphics,
         }: Parameters<'_>,
     ) {
         if let Event::MouseMoved(mouse_xy) = event {
-            self.update_last_cell(terrain, mouse_xy, &mut selection.cells, graphics);
+            update_last_cell(terrain, mouse_xy, cells, graphics);
             self.was_clear_interrupted = true;
         }
 
@@ -51,43 +51,41 @@ impl Handler {
             self.was_clear_interrupted = false;
         } else if !self.was_clear_interrupted
             && bindings.finish_clearing.binds_event(event)
-            && !selection.cells.is_empty()
+            && !cells.is_empty()
         {
-            selection.cells.clear();
-        } else if bindings.first_cell.binds_event(event) && selection.cells.is_empty() {
-            self.add_cell(terrain, mouse_xy, &mut selection.cells, graphics);
-            self.add_cell(terrain, mouse_xy, &mut selection.cells, graphics);
-        } else if bindings.second_cell.binds_event(event) && selection.cells.len() == 2 {
-            self.add_cell(terrain, mouse_xy, &mut selection.cells, graphics);
+            cells.clear();
+        } else if bindings.first_cell.binds_event(event) && cells.is_empty() {
+            add_cell(terrain, mouse_xy, cells, graphics);
+            add_cell(terrain, mouse_xy, cells, graphics);
+        } else if bindings.second_cell.binds_event(event) && cells.len() == 2 {
+            add_cell(terrain, mouse_xy, cells, graphics);
         }
     }
+}
 
-    fn add_cell(
-        &mut self,
-        terrain: &Grid<f32>,
-        mouse_xy: &Option<XY<u32>>,
-        cells: &mut Vec<XY<u32>>,
-        graphics: &mut dyn Graphics,
-    ) {
-        let Some(mouse_xy) = mouse_xy else {
-            return;
-        };
-        if let Some(selected_cell) = selected_cell(mouse_xy, graphics, terrain) {
-            cells.push(selected_cell);
-        }
+fn add_cell(
+    terrain: &Grid<f32>,
+    mouse_xy: &Option<XY<u32>>,
+    cells: &mut Vec<XY<u32>>,
+    graphics: &mut dyn Graphics,
+) {
+    let Some(mouse_xy) = mouse_xy else {
+        return;
+    };
+    if let Some(selected_cell) = selected_cell(mouse_xy, graphics, terrain) {
+        cells.push(selected_cell);
     }
+}
 
-    fn update_last_cell(
-        &mut self,
-        terrain: &Grid<f32>,
-        mouse_xy: &XY<u32>,
-        cells: &mut [XY<u32>],
-        graphics: &mut dyn Graphics,
-    ) {
-        if let Some(selected_cell) = selected_cell(mouse_xy, graphics, terrain) {
-            if let Some(last_cell) = cells.last_mut() {
-                *last_cell = selected_cell;
-            }
+fn update_last_cell(
+    terrain: &Grid<f32>,
+    mouse_xy: &XY<u32>,
+    cells: &mut [XY<u32>],
+    graphics: &mut dyn Graphics,
+) {
+    if let Some(selected_cell) = selected_cell(mouse_xy, graphics, terrain) {
+        if let Some(last_cell) = cells.last_mut() {
+            *last_cell = selected_cell;
         }
     }
 }

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -53,6 +53,7 @@ use crate::model::hash_vec::HashVec;
 use crate::model::lift::Lift;
 use crate::model::piste::{self, Piste};
 use crate::model::reservation::Reservation;
+use crate::model::selection::Selection;
 use crate::model::skier::{Clothes, Skier};
 use crate::model::skiing::{self, State};
 use crate::model::tree::Tree;
@@ -382,6 +383,7 @@ fn new_components() -> Components {
         terrain,
         trees,
         planning_queue: HashVec::new(),
+        selection: Selection::default(),
         services: Services {
             clock: services::clock::Service::new(),
             id_allocator: id_allocator::Service::new(),
@@ -433,6 +435,8 @@ pub struct Components {
     reservations: Grid<HashMap<usize, Reservation>>,
     piste_map: Grid<Option<usize>>,
     planning_queue: HashVec<usize>,
+    #[serde(skip)]
+    selection: Selection,
     services: Services,
 }
 
@@ -738,7 +742,7 @@ impl EventHandler for Game {
                 piste_map: &self.components.piste_map,
                 highlights: &self.components.highlights,
                 abilities: &self.components.abilities,
-                selection: &self.handlers.selection,
+                selection: &self.components.selection,
                 graphics,
             });
         self.systems.tree_artist.run(

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -62,8 +62,8 @@ use crate::systems::door::Parameters;
 use crate::systems::{
     building_artist, carousel, chair_artist, chair_framer, door, door_artist, frame_artist,
     frame_wiper, gate, gate_artist, global_computer, global_target_setter, lift_artist, log,
-    messenger, piste_adopter, planner, skiing_framer, target_scrubber, target_setter,
-    terrain_artist, tree_artist, window_artist,
+    messenger, piste_adopter, planner, selection_rasterizer, skiing_framer, target_scrubber,
+    target_setter, terrain_artist, tree_artist, window_artist,
 };
 use crate::utils::computer;
 use crate::widgets::{building_editor, main_menu, toaster};
@@ -573,7 +573,17 @@ impl EventHandler for Game {
             terrain_artist: &mut self.systems.terrain_artist,
             graphics,
         });
-        handlers::mode::handle(event, &self.bindings, &mut self.components.services.mode);
+        selection_rasterizer::run(selection_rasterizer::Parameters {
+            terrain: &self.components.terrain,
+            selection: &mut self.components.selection,
+            terrain_artist: &mut self.systems.terrain_artist,
+        });
+        handlers::mode::handle(
+            event,
+            &self.bindings,
+            &mut self.components.services.mode,
+            &mut self.components.selection,
+        );
 
         self.controllers
             .building_builder

--- a/mountain/src/model/mod.rs
+++ b/mountain/src/model/mod.rs
@@ -13,6 +13,7 @@ pub mod lift;
 pub mod message;
 pub mod piste;
 pub mod reservation;
+pub mod selection;
 pub mod skier;
 pub mod skiing;
 pub mod tree;

--- a/mountain/src/model/selection.rs
+++ b/mountain/src/model/selection.rs
@@ -1,0 +1,16 @@
+use commons::geometry::XY;
+use commons::origin_grid::OriginGrid;
+
+pub struct Selection {
+    pub cells: Vec<XY<u32>>,
+    pub grid: Option<OriginGrid<bool>>,
+}
+
+impl Default for Selection {
+    fn default() -> Self {
+        Self {
+            cells: Vec::with_capacity(3),
+            grid: None,
+        }
+    }
+}

--- a/mountain/src/services/mode.rs
+++ b/mountain/src/services/mode.rs
@@ -1,5 +1,6 @@
 use crate::controllers::Result::{self, Action, NoAction};
 use crate::handlers::selection::Parameters;
+use crate::model::selection::Selection;
 use crate::{controllers, Game};
 
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -37,8 +38,11 @@ impl Service {
         self.mode
     }
 
-    pub fn set_mode(&mut self, mode: Mode) {
+    pub fn set_mode(&mut self, mode: Mode, selection: &mut Selection) {
         self.mode = mode;
+        if !mode.has_selection() {
+            selection.cells.clear();
+        }
     }
 
     pub fn get_handler(
@@ -70,7 +74,6 @@ fn handle(
                 terrain: &game.components.terrain,
                 selection: &mut game.components.selection,
                 graphics,
-                terrain_artist: &mut game.systems.terrain_artist,
             },
         );
     }

--- a/mountain/src/services/mode.rs
+++ b/mountain/src/services/mode.rs
@@ -1,4 +1,5 @@
 use crate::controllers::Result::{self, Action, NoAction};
+use crate::handlers::selection::Parameters;
 use crate::{controllers, Game};
 
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
@@ -62,12 +63,15 @@ fn handle(
 
     if mode.has_selection() {
         game.handlers.selection.handle(
-            &game.bindings.selection,
             event,
-            &game.mouse_xy,
-            &game.components.terrain,
-            graphics,
-            &mut game.systems.terrain_artist,
+            Parameters {
+                bindings: &game.bindings.selection,
+                mouse_xy: &game.mouse_xy,
+                terrain: &game.components.terrain,
+                selection: &mut game.components.selection,
+                graphics,
+                terrain_artist: &mut game.systems.terrain_artist,
+            },
         );
     }
 }
@@ -102,7 +106,7 @@ fn try_to_handle(
             .trigger(controllers::piste_builder::Parameters {
                 pistes: &mut game.components.pistes,
                 piste_map: &mut game.components.piste_map,
-                selection: &mut game.handlers.selection,
+                selection: &mut game.components.selection,
                 terrain_artist: &mut game.systems.terrain_artist,
                 tree_artist: &mut game.systems.tree_artist,
                 id_allocator: &mut game.components.services.id_allocator,
@@ -113,7 +117,7 @@ fn try_to_handle(
                     .trigger(controllers::piste_eraser::Parameters {
                         pistes: &mut game.components.pistes,
                         piste_map: &mut game.components.piste_map,
-                        selection: &mut game.handlers.selection,
+                        selection: &mut game.components.selection,
                         terrain_artist: &mut game.systems.terrain_artist,
                         tree_artist: &mut game.systems.tree_artist,
                     })
@@ -124,7 +128,7 @@ fn try_to_handle(
             .trigger(controllers::piste_builder::Parameters {
                 pistes: &mut game.components.pistes,
                 piste_map: &mut game.components.piste_map,
-                selection: &mut game.handlers.selection,
+                selection: &mut game.components.selection,
                 terrain_artist: &mut game.systems.terrain_artist,
                 tree_artist: &mut game.systems.tree_artist,
                 id_allocator: &mut game.components.services.id_allocator,
@@ -135,7 +139,7 @@ fn try_to_handle(
                     .trigger(controllers::piste_eraser::Parameters {
                         pistes: &mut game.components.pistes,
                         piste_map: &mut game.components.piste_map,
-                        selection: &mut game.handlers.selection,
+                        selection: &mut game.components.selection,
                         terrain_artist: &mut game.systems.terrain_artist,
                         tree_artist: &mut game.systems.tree_artist,
                     })
@@ -161,7 +165,7 @@ fn try_to_handle(
         }
         Mode::Building => game.controllers.building_builder.select(
             controllers::building_builder::SelectParameters {
-                selection: &mut game.handlers.selection,
+                selection: &mut game.components.selection,
                 id_allocator: &mut game.components.services.id_allocator,
                 buildings: &mut game.components.buildings,
                 tree_artist: &mut game.systems.tree_artist,
@@ -170,7 +174,7 @@ fn try_to_handle(
         Mode::Gate => controllers::gate_builder::trigger(controllers::gate_builder::Parameters {
             piste_map: &game.components.piste_map,
             terrain: &game.components.terrain,
-            selection: &mut game.handlers.selection,
+            selection: &mut game.components.selection,
             terrain_artist: &mut game.systems.terrain_artist,
             id_allocator: &mut game.components.services.id_allocator,
             gates: &mut game.components.gates,
@@ -184,7 +188,7 @@ fn try_to_handle(
             pistes: &game.components.pistes,
             buildings: &game.components.buildings,
             terrain: &game.components.terrain,
-            selection: &mut game.handlers.selection,
+            selection: &mut game.components.selection,
             id_allocator: &mut game.components.services.id_allocator,
             doors: &mut game.components.doors,
             entrances: &mut game.components.entrances,

--- a/mountain/src/systems/mod.rs
+++ b/mountain/src/systems/mod.rs
@@ -15,6 +15,7 @@ pub mod log;
 pub mod messenger;
 pub mod piste_adopter;
 pub mod planner;
+pub mod selection_rasterizer;
 pub mod skier_colors;
 pub mod skiing_framer;
 pub mod target_scrubber;

--- a/mountain/src/systems/selection_rasterizer.rs
+++ b/mountain/src/systems/selection_rasterizer.rs
@@ -1,0 +1,167 @@
+use commons::geometry::{project_point_onto_line, xy, Line, XYRectangle, XY};
+use commons::grid::{Grid, OFFSETS_4};
+use commons::origin_grid::OriginGrid;
+use line_drawing::Bresenham;
+
+use crate::model::selection::Selection;
+use crate::systems::terrain_artist;
+
+pub struct Parameters<'a> {
+    pub terrain: &'a Grid<f32>,
+    pub selection: &'a mut Selection,
+    pub terrain_artist: &'a mut terrain_artist::System,
+}
+
+pub fn run(
+    Parameters {
+        terrain,
+        selection,
+        terrain_artist,
+    }: Parameters<'_>,
+) {
+    let previous_grid = selection.grid.clone();
+
+    rasterize(terrain, selection);
+
+    let new_grid = &selection.grid;
+    if previous_grid != *new_grid {
+        previous_grid
+            .iter()
+            .chain(new_grid.iter())
+            .flat_map(|grid| grid.rectangle())
+            .for_each(|rectangle| terrain_artist.update_overlay(rectangle));
+    }
+}
+
+fn rasterize(terrain: &Grid<f32>, selection: &mut Selection) {
+    selection.grid = None;
+
+    let cells = &selection.cells;
+    if cells.len() < 2 {
+        return;
+    }
+
+    // Computing border
+
+    let mut border = Vec::with_capacity(5);
+
+    if cells.len() == 2 {
+        border.push(cells[0]);
+        border.push(cells[1]);
+    } else if cells.len() == 3 {
+        border.push(cells[0]);
+
+        let Some(border_1) = compute_border_1(&selection.cells) else {
+            return;
+        };
+        if border_1.x > terrain.width() - 2 || border_1.y > terrain.height() {
+            return;
+        }
+        border.push(border_1);
+
+        border.push(cells[2]);
+
+        let border_3 = to_xy_i32(&border[2]) - (to_xy_i32(&border[1]) - to_xy_i32(&border[0]));
+        if border_3.x < 0 || border_3.y < 0 {
+            return;
+        }
+        let border_3 = xy(border_3.x as u32, border_3.y as u32);
+        if border_3.x > terrain.width() - 2 || border_3.y > terrain.height() {
+            return;
+        }
+        border.push(border_3);
+
+        // Adding fifth cell so final line is picked up by windows(2) below
+        border.push(cells[0]);
+    }
+
+    // Creating grid
+
+    let mut grid = OriginGrid::from_rectangle(
+        XYRectangle {
+            from: xy(
+                border.iter().map(|point| point.x).min().unwrap(),
+                border.iter().map(|point| point.y).min().unwrap(),
+            ),
+            to: xy(
+                border.iter().map(|point| point.x).max().unwrap(),
+                border.iter().map(|point| point.y).max().unwrap(),
+            ),
+        },
+        false,
+    );
+
+    // Rasterizing
+
+    for pair in border.windows(2) {
+        rasterize_line(&mut grid, &pair[0], &pair[1]);
+    }
+    let filled = fill_cells_inaccessible_from_border(&grid);
+
+    selection.grid = Some(filled)
+}
+
+fn to_xy_i32(XY { x, y }: &XY<u32>) -> XY<i32> {
+    xy(*x as i32, *y as i32)
+}
+
+fn to_xy_f32(XY { x, y }: &XY<u32>) -> XY<f32> {
+    xy(*x as f32, *y as f32)
+}
+
+fn compute_border_1(cells: &[XY<u32>]) -> Option<XY<u32>> {
+    // Case where user did not drag
+    let to = if cells[0] == cells[1] {
+        // Default is a grid aligned to the x-axis
+        cells[0] + xy(1, 0)
+    } else {
+        cells[1]
+    };
+
+    let out = project_point_onto_line(
+        to_xy_f32(&cells[2]),
+        Line {
+            from: to_xy_f32(&cells[0]),
+            to: to_xy_f32(&to),
+        },
+    );
+
+    let Ok(out) = out else {
+        return None;
+    };
+    let out = xy(out.x.round(), out.y.round());
+    if out.x < 0.0 || out.y < 0.0 {
+        return None;
+    }
+    Some(xy(out.x as u32, out.y as u32))
+}
+
+fn rasterize_line(grid: &mut OriginGrid<bool>, from: &XY<u32>, to: &XY<u32>) {
+    for (x, y) in Bresenham::new((from.x as i32, from.y as i32), (to.x as i32, to.y as i32)) {
+        grid[xy(x as u32, y as u32)] = true;
+    }
+}
+
+fn fill_cells_inaccessible_from_border(grid: &OriginGrid<bool>) -> OriginGrid<bool> {
+    let border = grid
+        .iter()
+        .filter(|xy| !grid[xy])
+        .filter(|xy| grid.is_border(xy));
+
+    let mut out = grid.map(|_, _| true);
+    let mut queue = Vec::with_capacity((grid.width() * grid.height()) as usize);
+    for cell in border {
+        out[cell] = false;
+        queue.push(cell);
+    }
+
+    while let Some(cell) = queue.pop() {
+        for neighbour in grid.offsets(cell, &OFFSETS_4).collect::<Vec<_>>() {
+            if !grid[neighbour] && out[neighbour] {
+                out[neighbour] = false;
+                queue.push(neighbour);
+            }
+        }
+    }
+    out
+}

--- a/mountain/src/systems/terrain_artist.rs
+++ b/mountain/src/systems/terrain_artist.rs
@@ -7,8 +7,8 @@ use commons::origin_grid::OriginGrid;
 use engine::graphics::Graphics;
 
 use crate::draw::terrain::Drawing;
-use crate::handlers::selection;
 use crate::model::ability::Ability;
+use crate::model::selection::Selection;
 use crate::utils::ability::cell_ability;
 
 pub const CLEAR: Rgba<u8> = Rgba::new(0, 0, 0, 0);
@@ -39,7 +39,7 @@ impl Colors {
         &self,
         xy: &XY<u32>,
         terrain: &Grid<f32>,
-        selection: &selection::Handler,
+        selection: &Selection,
     ) -> Option<Rgba<u8>> {
         let grid = selection.grid.as_ref()?;
 
@@ -97,7 +97,7 @@ pub struct Parameters<'a> {
     pub piste_map: &'a Grid<Option<usize>>,
     pub highlights: &'a HashSet<usize>,
     pub abilities: &'a HashMap<usize, Ability>,
-    pub selection: &'a selection::Handler,
+    pub selection: &'a Selection,
     pub graphics: &'a mut dyn Graphics,
 }
 


### PR DESCRIPTION
Separated the state, event handling and rasterization parts of selection_handler. Rasterization always runs, event handling only runs in certain modes. Selection is cleared when switching modes.