### PR TITLE
feat (mountain): skiers now always need a path back to their hotel

### DIFF
--- a/mountain/src/controllers/building_remover.rs
+++ b/mountain/src/controllers/building_remover.rs
@@ -84,6 +84,8 @@ pub fn remove_building(
     for door_id in doors_to_remove.iter() {
         components.doors.remove(door_id);
         components.entrances.remove(door_id);
+        components.exits.remove(door_id);
+        components.open.remove(door_id);
         remove_drawing(graphics, components, door_id);
     }
 

--- a/mountain/src/controllers/door_builder.rs
+++ b/mountain/src/controllers/door_builder.rs
@@ -10,6 +10,7 @@ use crate::model::door::Door;
 
 use crate::controllers::Result::{self, Action, NoAction};
 use crate::model::entrance::Entrance;
+use crate::model::exit::Exit;
 use crate::model::piste::Piste;
 use crate::model::selection::Selection;
 use crate::model::skiing::State;
@@ -24,6 +25,8 @@ pub struct Parameters<'a> {
     pub id_allocator: &'a mut id_allocator::Service,
     pub doors: &'a mut HashMap<usize, Door>,
     pub entrances: &'a mut HashMap<usize, Entrance>,
+    pub exits: &'a mut HashMap<usize, Exit>,
+    pub open: &'a mut HashSet<usize>,
     pub messenger: &'a mut messenger::System,
 }
 
@@ -36,6 +39,8 @@ pub fn trigger(
         id_allocator,
         doors,
         entrances,
+        exits,
+        open,
         messenger,
     }: Parameters<'_>,
 ) -> Result {
@@ -125,6 +130,14 @@ pub fn trigger(
             altitude_meters: altitude_meters(terrain, &piste_positions),
         },
     );
+    exits.insert(
+        door_id,
+        Exit {
+            origin_piste_id: *piste_id,
+            stationary_states: stationary_states(&piste_positions),
+        },
+    );
+    open.insert(door_id);
 
     selection.cells.clear();
 

--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -746,6 +746,7 @@ impl EventHandler for Game {
             locations: &self.components.locations,
             entrances: &self.components.entrances,
             pistes: &self.components.pistes,
+            doors: &self.components.doors,
             costs: &self.components.costs,
             global_costs: &self.components.global_costs,
             global_targets: &mut self.components.global_targets,

--- a/mountain/src/services/mode.rs
+++ b/mountain/src/services/mode.rs
@@ -195,6 +195,8 @@ fn try_to_handle(
             id_allocator: &mut game.components.services.id_allocator,
             doors: &mut game.components.doors,
             entrances: &mut game.components.entrances,
+            exits: &mut game.components.exits,
+            open: &mut game.components.open,
             messenger: &mut game.systems.messenger,
         }),
         Mode::Demolish => try_to_demolish(game, graphics),


### PR DESCRIPTION
This replaces the error prone rule where skiers could choose a global target with at least one edge leading out - but with no guarantees that there was a sensible path continuing from that edge.

Another alternative is that skiers should always be able to return to their current position, but this makes it impossible to close parts of the network that have skiers in.