### PR TITLE
feat (mountain): pistes must be closed to build lifts etc

### DIFF
--- a/mountain/src/controllers/door_builder.rs
+++ b/mountain/src/controllers/door_builder.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use commons::geometry::{xy, XYRectangle, XY};
+use commons::map::ContainsKeyValue;
 
 use crate::model::building::Building;
 
@@ -105,6 +106,14 @@ pub fn trigger(
         selection.cells.clear();
         return NoAction;
     };
+
+    if !open.contains_key_value(piste_id, open::Status::Closed) {
+        messenger.send(format!(
+            "Piste {} must be closed before an entrance can be added to it",
+            piste_id
+        ));
+        return NoAction;
+    }
 
     let aperture = piste_positions
         .iter()

--- a/mountain/src/controllers/gate_builder.rs
+++ b/mountain/src/controllers/gate_builder.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use commons::geometry::{xy, XYRectangle};
 use commons::grid::Grid;
+use commons::map::ContainsKeyValue;
 
 use crate::controllers;
 use crate::controllers::Result::{Action, NoAction};
@@ -104,6 +105,25 @@ pub fn trigger(
     // creating gate
 
     let gate_id = id_allocator.next_id();
+    let origin_piste_id = piste_map[origin].unwrap();
+    let destination_piste_id =
+        (configuration.pistes[0] + configuration.pistes[1]) - origin_piste_id;
+
+    if !open.contains_key_value(origin_piste_id, open::Status::Closed) {
+        messenger.send(format!(
+            "Piste {} must be closed before an gate can be added to it",
+            origin_piste_id
+        ));
+        return NoAction;
+    }
+
+    if !open.contains_key_value(destination_piste_id, open::Status::Closed) {
+        messenger.send(format!(
+            "Piste {} must be closed before an gate can be added to it",
+            destination_piste_id
+        ));
+        return NoAction;
+    }
 
     // reserving footprint
 
@@ -112,10 +132,6 @@ pub fn trigger(
     });
 
     // creating entrance and exit
-
-    let origin_piste_id = piste_map[origin].unwrap();
-    let destination_piste_id =
-        (configuration.pistes[0] + configuration.pistes[1]) - origin_piste_id;
 
     let stationary_states = gate
         .footprint

--- a/mountain/src/controllers/gate_remover.rs
+++ b/mountain/src/controllers/gate_remover.rs
@@ -49,11 +49,11 @@ pub fn remove_gate(
 ) {
     // Validate
 
-    if components
+    if !components
         .open
         .contains_key_value(gate_id, open::Status::Open)
     {
-        messenger.send(format!("Close gate {} before removing it!", gate_id));
+        messenger.send(format!("Gate {} before removing it!", gate_id));
         return;
     }
 
@@ -67,6 +67,32 @@ pub fn remove_gate(
             gate_id
         ));
         return;
+    }
+
+    if let Some(entrance) = components.entrances.get(gate_id) {
+        if !components
+            .open
+            .contains_key_value(entrance.destination_piste_id, open::Status::Closed)
+        {
+            messenger.send(format!(
+                "Piste {} must be closed before gate {} can be removed from it",
+                entrance.destination_piste_id, gate_id
+            ));
+            return;
+        }
+    }
+
+    if let Some(exit) = components.exits.get(gate_id) {
+        if !components
+            .open
+            .contains_key_value(exit.origin_piste_id, open::Status::Closed)
+        {
+            messenger.send(format!(
+                "Piste {} must be closed before gate {} can be removed from it",
+                exit.origin_piste_id, gate_id
+            ));
+            return;
+        }
     }
 
     // Remove

--- a/mountain/src/controllers/gate_remover.rs
+++ b/mountain/src/controllers/gate_remover.rs
@@ -69,19 +69,6 @@ pub fn remove_gate(
         return;
     }
 
-    if let Some(entrance) = components.entrances.get(gate_id) {
-        if !components
-            .open
-            .contains_key_value(entrance.destination_piste_id, open::Status::Closed)
-        {
-            messenger.send(format!(
-                "Piste {} must be closed before gate {} can be removed from it",
-                entrance.destination_piste_id, gate_id
-            ));
-            return;
-        }
-    }
-
     if let Some(exit) = components.exits.get(gate_id) {
         if !components
             .open

--- a/mountain/src/controllers/lift_remover.rs
+++ b/mountain/src/controllers/lift_remover.rs
@@ -70,6 +70,32 @@ pub fn remove_lift(
         return;
     }
 
+    if let Some(entrance) = components.entrances.get(lift_id) {
+        if !components
+            .open
+            .contains_key_value(entrance.destination_piste_id, open::Status::Closed)
+        {
+            messenger.send(format!(
+                "Piste {} must be closed before lift {} can be removed from it",
+                entrance.destination_piste_id, lift_id
+            ));
+            return;
+        }
+    }
+
+    if let Some(exit) = components.exits.get(lift_id) {
+        if !components
+            .open
+            .contains_key_value(exit.origin_piste_id, open::Status::Closed)
+        {
+            messenger.send(format!(
+                "Piste {} must be closed before lift {} can be removed from it",
+                exit.origin_piste_id, lift_id
+            ));
+            return;
+        }
+    }
+
     // Remove
 
     let lift = components.lifts.remove(lift_id);

--- a/mountain/src/controllers/lift_remover.rs
+++ b/mountain/src/controllers/lift_remover.rs
@@ -70,19 +70,6 @@ pub fn remove_lift(
         return;
     }
 
-    if let Some(entrance) = components.entrances.get(lift_id) {
-        if !components
-            .open
-            .contains_key_value(entrance.destination_piste_id, open::Status::Closed)
-        {
-            messenger.send(format!(
-                "Piste {} must be closed before lift {} can be removed from it",
-                entrance.destination_piste_id, lift_id
-            ));
-            return;
-        }
-    }
-
     if let Some(exit) = components.exits.get(lift_id) {
         if !components
             .open


### PR DESCRIPTION
Both origin/destination pistes must be closed to
- Build lifts
- Build gates

This is to force re-computation when the piste is re-opened.

Destination piste must be closed to
- Build doors

This is to force re-computation when the piste is re-opened.

Only origin piste (found via exit) must be closed to
- Remove lifts
- Remove gates

This is to force re-computation when the piste is re-opened (even though the removed routes would just be unused in the calculations).

Doors are removed with buildings, there is no restriction on this because doors have no origin piste.