### PR TITLE
fix (engine): drawing holograms after solids

### DIFF
--- a/engine/src/graphics/mod.rs
+++ b/engine/src/graphics/mod.rs
@@ -21,7 +21,7 @@ use crate::graphics::errors::{
     DrawError, IndexError, InitializationError, RenderError, ScreenshotError,
 };
 
-#[derive(Default, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
 pub enum DrawMode {
     #[default]
     Solid,


### PR DESCRIPTION
We overwrite w in rgba with z for computing screen to world coordinates later.

If a pixel belongs to a hologram, we want the z-value of the pixel behind to be in w. However if the hologram is drawn first and is in front, the pixel behind will never be drawn.

We therefore need to draw solids first.


