### PR TITLE
feat (mountain): modes no longer toggle on and off

### DIFF
--- a/mountain/src/gui.rs
+++ b/mountain/src/gui.rs
@@ -254,17 +254,10 @@ pub fn run(
     for (i, &clicked) in mode_button_clicked.iter().enumerate() {
         if clicked {
             let config = &MODE_BUTTONS[i];
-            if build_mode == config.build_mode {
-                game.components
-                    .services
-                    .mode
-                    .set_mode(mode::Mode::None, &mut game.components.selection);
-            } else {
-                game.components
-                    .services
-                    .mode
-                    .set_mode(config.build_mode, &mut game.components.selection);
-            };
+            game.components
+                .services
+                .mode
+                .set_mode(config.build_mode, &mut game.components.selection);
         }
     }
 

--- a/mountain/src/handlers/mode.rs
+++ b/mountain/src/handlers/mode.rs
@@ -1,5 +1,4 @@
 use crate::model::selection::Selection;
-use crate::services::mode::Mode;
 use crate::{services, Bindings};
 
 pub fn handle(
@@ -10,11 +9,7 @@ pub fn handle(
 ) {
     for (&mode, binding) in bindings.mode.iter() {
         if binding.binds_event(event) {
-            if service.mode() == mode {
-                service.set_mode(Mode::None, selection);
-            } else {
-                service.set_mode(mode, selection);
-            }
+            service.set_mode(mode, selection);
             return;
         }
     }

--- a/mountain/src/services/mode.rs
+++ b/mountain/src/services/mode.rs
@@ -7,7 +7,6 @@ use crate::{controllers, Game};
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 pub enum Mode {
     #[default]
-    None,
     Query,
     Piste,
     PisteEraser,


### PR DESCRIPTION
This improves playability since you can press e.g. P and be guaranteed you'll be in piste mode (without having to check if you're already in piste mode).