### PR TITLE
fix (mountain): rotation jumping after loading game

### DIFF
--- a/mountain/src/main.rs
+++ b/mountain/src/main.rs
@@ -553,6 +553,9 @@ impl Game {
     fn init(&mut self, graphics: &mut dyn Graphics) {
         self.try_create_save_directory();
         let terrain = &self.components.terrain;
+
+        self.handlers.yaw.init(graphics);
+        self.handlers.zoom.init(graphics);
         self.systems.chair_artist.init(graphics);
         self.systems.terrain_artist.init(graphics, terrain);
         self.systems.tree_artist.init(graphics);


### PR DESCRIPTION
Jumping was because yaw and zoom handlers are recreated and become out of sync with the engine.

Would be better to reuse old drag, yaw and zoom handlers which are already consistent with the engine.